### PR TITLE
Add delete confirmation dialog for preset deletion

### DIFF
--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/preset/PresetListScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/preset/PresetListScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -24,6 +25,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
@@ -65,6 +67,28 @@ public fun PresetListScreen(
                 uiState.event.onDismissNameInput()
             },
             default = "",
+        )
+    }
+
+    if (uiState.deleteConfirmationDialog != null) {
+        AlertDialog(
+            onDismissRequest = { uiState.deleteConfirmationDialog.event.onCancel() },
+            title = { Text("プリセットを削除しますか？") },
+            text = { Text("「${uiState.deleteConfirmationDialog.presetName}」を削除します。この操作は取り消せません。") },
+            confirmButton = {
+                TextButton(
+                    onClick = { uiState.deleteConfirmationDialog.event.onConfirm() },
+                ) {
+                    Text("削除")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { uiState.deleteConfirmationDialog.event.onCancel() },
+                ) {
+                    Text("キャンセル")
+                }
+            },
         )
     }
 

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/preset/PresetListScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/preset/PresetListScreen.kt
@@ -74,7 +74,7 @@ public fun PresetListScreen(
         AlertDialog(
             onDismissRequest = { uiState.deleteConfirmationDialog.event.onCancel() },
             title = { Text("プリセットを削除しますか？") },
-            text = { Text("「${uiState.deleteConfirmationDialog.presetName}」を削除します。この操作は取り消せません。") },
+            text = { Text("「${uiState.deleteConfirmationDialog.presetName}」を削除しますか？") },
             confirmButton = {
                 TextButton(
                     onClick = { uiState.deleteConfirmationDialog.event.onConfirm() },

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/preset/PresetListScreenUiState.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/preset/PresetListScreenUiState.kt
@@ -8,8 +8,20 @@ public data class PresetListScreenUiState(
     val kakeboScaffoldListener: KakeboScaffoldListener,
     val loadingState: LoadingState,
     val showNameInput: Boolean,
+    val deleteConfirmationDialog: DeleteConfirmationDialog?,
     val event: Event,
 ) {
+    public data class DeleteConfirmationDialog(
+        val presetName: String,
+        val event: DeleteConfirmationEvent,
+    ) {
+        @Immutable
+        public interface DeleteConfirmationEvent {
+            public fun onConfirm()
+
+            public fun onCancel()
+        }
+    }
     public sealed interface LoadingState {
         public data object Loading : LoadingState
         public data object Error : LoadingState

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/preset/PresetListViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/preset/PresetListViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.matsudamper.money.element.MoneyUsagePresetId
 import net.matsudamper.money.frontend.common.base.ImmutableList.Companion.toImmutableList
 import net.matsudamper.money.frontend.common.base.nav.ScopedObjectFeature
 import net.matsudamper.money.frontend.common.base.nav.user.ScreenNavController
@@ -32,6 +33,7 @@ public class PresetListViewModel(
             isLoading = true,
             showNameInput = false,
             isError = false,
+            deleteConfirmationPresetId = null,
         ),
     )
 
@@ -47,6 +49,7 @@ public class PresetListViewModel(
             },
             loadingState = PresetListScreenUiState.LoadingState.Loading,
             showNameInput = false,
+            deleteConfirmationDialog = null,
             event = object : PresetListScreenUiState.Event {
                 override fun onResume() {
                     fetchCollect()
@@ -102,14 +105,48 @@ public class PresetListViewModel(
                             }.toImmutableList(),
                         )
                     }
+                    val deleteConfirmationDialog = viewModelState.deleteConfirmationPresetId?.let { presetId ->
+                        val preset = viewModelState.presets.find { it.id == presetId }
+                        if (preset != null) {
+                            PresetListScreenUiState.DeleteConfirmationDialog(
+                                presetName = preset.name,
+                                event = object : PresetListScreenUiState.DeleteConfirmationDialog.DeleteConfirmationEvent {
+                                    override fun onConfirm() {
+                                        viewModelScope.launch {
+                                            confirmDelete(presetId)
+                                        }
+                                    }
+
+                                    override fun onCancel() {
+                                        viewModelStateFlow.update { it.copy(deleteConfirmationPresetId = null) }
+                                    }
+                                },
+                            )
+                        } else {
+                            null
+                        }
+                    }
                     uiState.copy(
                         loadingState = loadingState,
                         showNameInput = viewModelState.showNameInput,
+                        deleteConfirmationDialog = deleteConfirmationDialog,
                     )
                 }
             }
         }
     }.asStateFlow()
+
+    private suspend fun confirmDelete(presetId: MoneyUsagePresetId) {
+        val deleted = api.deletePreset(presetId)
+        viewModelStateFlow.update { it.copy(deleteConfirmationPresetId = null) }
+        if (!deleted) {
+            globalEventSender.send {
+                it.showNativeNotification("削除に失敗しました")
+            }
+            return
+        }
+        fetchCollect()
+    }
 
     private var fetchJob: Job = Job()
     private fun fetchCollect() {
@@ -157,16 +194,7 @@ public class PresetListViewModel(
         }
 
         override fun onClickDelete() {
-            viewModelScope.launch {
-                val deleted = api.deletePreset(preset.id)
-                if (!deleted) {
-                    globalEventSender.send {
-                        it.showNativeNotification("削除に失敗しました")
-                    }
-                    return@launch
-                }
-                fetchCollect()
-            }
+            viewModelStateFlow.update { it.copy(deleteConfirmationPresetId = preset.id) }
         }
 
         override fun onClickEdit() {
@@ -183,5 +211,6 @@ public class PresetListViewModel(
         val presets: List<GetMoneyUsagePresetsQuery.MoneyUsagePreset>,
         val isError: Boolean,
         val showNameInput: Boolean,
+        val deleteConfirmationPresetId: MoneyUsagePresetId?,
     )
 }


### PR DESCRIPTION
## Summary
Implemented a confirmation dialog for preset deletion to prevent accidental deletions. The delete action now shows a confirmation dialog before proceeding with the deletion.

## Key Changes
- **ViewModel State Management**: Added `deleteConfirmationPresetId` field to track which preset is pending deletion
- **Confirmation Dialog UI**: Created `DeleteConfirmationDialog` data class in `PresetListScreenUiState` with callback events for confirm/cancel actions
- **Delete Flow Refactoring**: Moved deletion logic from immediate execution to a two-step process:
  - `onClickDelete()` now sets the preset ID for confirmation instead of immediately deleting
  - New `confirmDelete()` suspend function handles the actual deletion after confirmation
- **UI Implementation**: Added Material3 `AlertDialog` to `PresetListScreen` that displays the preset name and confirmation/cancel buttons
- **Error Handling**: Preserved existing error notification behavior when deletion fails

## Implementation Details
- The confirmation dialog is conditionally rendered only when `deleteConfirmationPresetId` is not null
- Dialog callbacks properly update the ViewModel state to clear the confirmation ID on cancel
- The preset name is displayed in the confirmation message for better UX
- Deletion operation is cancelled if the preset is not found in the current state

https://claude.ai/code/session_01DMHm8YyqvqsYL9QEmBkUSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プリセット削除時に確認ダイアログが表示されるようになりました。誤削除を防ぐため、削除前に明示的な確認が必要です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->