### PR TITLE
月別の画面からカテゴリやサブカテゴリの月別の画面に飛べるようにする

### DIFF
--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
@@ -32,6 +32,7 @@ import net.matsudamper.money.frontend.common.base.nav.user.RootHomeScreenStructu
 import net.matsudamper.money.frontend.common.base.nav.user.ScreenNavController
 import net.matsudamper.money.frontend.common.base.nav.user.ScreenStructure
 import net.matsudamper.money.frontend.common.ui.layout.graph.pie.PieChartItem
+import net.matsudamper.money.frontend.common.ui.layout.graph.pie.PieChartItemEvent
 import net.matsudamper.money.frontend.common.ui.screen.root.home.SortSectionOrder
 import net.matsudamper.money.frontend.common.ui.screen.root.home.SortSectionType
 import net.matsudamper.money.frontend.common.ui.screen.root.home.monthly.RootHomeMonthlyScreenUiState
@@ -159,18 +160,33 @@ public class RootHomeMonthlyScreenViewModel(
     }.asStateFlow()
 
     private fun createLoadedUiState(viewModelState: ViewModelState): RootHomeMonthlyScreenUiState.LoadingState.Loaded {
+        val sinceDate = createSinceLocalDateTime().date
+
         val pieChartItems = viewModelState.moneyUsageAnalytics?.byCategories?.mapIndexed { index, byCategory ->
             PieChartItem(
                 title = byCategory.category.name,
                 color = reservedColorModel.getColor(byCategory.category.name),
                 value = byCategory.totalAmount ?: 0,
+                event = object : PieChartItemEvent {
+                    override fun onClick() {
+                        viewModelScope.launch {
+                            eventSender.send {
+                                it.navigate(
+                                    RootHomeScreenStructure.MonthlyCategory(
+                                        categoryId = byCategory.category.id,
+                                        year = sinceDate.year,
+                                        month = sinceDate.monthNumber,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+                },
             )
         }.orEmpty().sortedByDescending { it.value }
 
         val response = (viewModelState.monthlyListResponse as? ApolloResponseState.Success)?.value
         val nodes = response?.data?.user?.moneyUsages?.nodes.orEmpty()
-
-        val sinceDate = createSinceLocalDateTime().date
 
         return RootHomeMonthlyScreenUiState.LoadingState.Loaded(
             yearMonth = "${sinceDate.year}年${sinceDate.monthNumber}月",

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/category/RootHomeMonthlyCategoryScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/category/RootHomeMonthlyCategoryScreenViewModel.kt
@@ -206,19 +206,34 @@ public class RootHomeMonthlyCategoryScreenViewModel(
 
     private fun createPieChartItems(nodes: List<MonthlyCategoryScreenListQuery.Node>): ImmutableList<PieChartItem> {
         return nodes
-            .groupBy { it.moneyUsageSubCategory?.name ?: "その他" }
-            .mapValues { (_, nodes) -> nodes.sumOf { it.amount } }
+            .groupBy { it.moneyUsageSubCategory?.id to (it.moneyUsageSubCategory?.name ?: "その他") }
+            .mapValues { (_, groupedNodes) -> groupedNodes.sumOf { it.amount } }
             .filter { it.value > 0 }
             .entries
-            .mapIndexed { index, (subCategory, amount) ->
+            .map { (subCategoryKey, amount) ->
+                val (subCategoryId, subCategoryName) = subCategoryKey
                 PieChartItem(
-                    color = reservedColorModel.getColor(subCategory),
-                    title = subCategory,
+                    color = reservedColorModel.getColor(subCategoryName),
+                    title = subCategoryName,
                     value = amount.toLong(),
-                    event = object : PieChartItemEvent {
-                        override fun onClick() {
-                            // TODO
+                    event = if (subCategoryId != null) {
+                        object : PieChartItemEvent {
+                            override fun onClick() {
+                                viewModelScope.launch {
+                                    eventSender.send {
+                                        it.navigate(
+                                            RootHomeScreenStructure.MonthlySubCategory(
+                                                subCategoryId = subCategoryId,
+                                                year = viewModelStateFlow.value.year,
+                                                month = viewModelStateFlow.value.month,
+                                            ),
+                                        )
+                                    }
+                                }
+                            }
                         }
+                    } else {
+                        null
                     },
                 )
             }.toImmutableList()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 月次パイチャートのアイテムをクリックして詳細ページへ遷移できるようになりました。
  * カテゴリーおよびサブカテゴリーのナビゲーション機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->