### PR TITLE
Use LocalRootScaffoldPadding instead of windowInsets parameter

### DIFF
--- a/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/RootNavContent.kt
+++ b/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/RootNavContent.kt
@@ -20,6 +20,7 @@ import net.matsudamper.money.frontend.common.base.notification.NotificationUsage
 import net.matsudamper.money.frontend.common.base.notification.NotificationUsageParser
 import net.matsudamper.money.frontend.common.base.notification.NotificationUsageRepository
 import net.matsudamper.money.frontend.common.ui.StickyHeaderState
+import net.matsudamper.money.frontend.common.ui.base.LocalRootScaffoldPadding
 import net.matsudamper.money.frontend.common.ui.screen.root.home.RootHomeMonthlyCategoryScreen
 import net.matsudamper.money.frontend.common.ui.screen.root.home.RootHomeMonthlySubCategoryScreen
 import net.matsudamper.money.frontend.common.ui.screen.root.home.RootHomeTabPeriodAllContentUiState
@@ -268,7 +269,7 @@ internal fun RootNavContent(
                             modifier = Modifier.fillMaxSize(),
                             stickyHeaderState = stickyHeaderState,
                             uiState = rootUiState,
-                            windowInsets = windowInsets,
+                            windowInsets = LocalRootScaffoldPadding.current,
                         ) {
                             content()
                         }


### PR DESCRIPTION
## Summary
Refactored the RootNavContent to use the `LocalRootScaffoldPadding` composition local instead of passing `windowInsets` as a direct parameter to the RootHomeScreen composable.

## Key Changes
- Added import for `LocalRootScaffoldPadding` from the UI base package
- Replaced the `windowInsets` parameter with `LocalRootScaffoldPadding.current` when calling RootHomeScreen
- This change leverages Compose's composition local pattern for better dependency management and cleaner API

## Implementation Details
This refactoring improves the architecture by using Compose's composition local mechanism to provide padding information through the composition hierarchy rather than explicit parameter passing. This approach is more idiomatic in Compose and reduces parameter coupling.

https://claude.ai/code/session_01RriNHoL2WCSCrQc8rmGfue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * UI レイアウトのパディング処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->