### PR TITLE
フィルターを削除後に前の画面に戻す

### DIFF
--- a/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/ViewModelEventHandlers.kt
+++ b/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/ViewModelEventHandlers.kt
@@ -240,6 +240,14 @@ internal data class ViewModelEventHandlers(
                     override fun navigate(structure: ScreenStructure) {
                         navController.navigate(structure)
                     }
+
+                    override fun navigateBack() {
+                        if (navController.canGoBack) {
+                            navController.back()
+                        } else {
+                            navController.navigate(ScreenStructure.Root.Settings.MailCategoryFilters)
+                        }
+                    }
                 },
             )
         }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilter/ImportedMailFilterCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilter/ImportedMailFilterCategoryViewModel.kt
@@ -95,7 +95,7 @@ public class ImportedMailFilterCategoryViewModel(
                                         dismissConfirmDialog()
                                         if (isSuccess) {
                                             eventSender.send {
-                                                it.navigate(ScreenStructure.Root.Settings.MailCategoryFilters)
+                                                it.navigateBack()
                                             }
                                         } else {
                                             snackbarEventState.show(
@@ -115,7 +115,7 @@ public class ImportedMailFilterCategoryViewModel(
                 override fun onClickBack() {
                     viewModelScope.launch {
                         eventSender.send {
-                            it.navigate(ScreenStructure.Root.Settings.MailCategoryFilters)
+                            it.navigateBack()
                         }
                     }
                 }
@@ -391,6 +391,8 @@ public class ImportedMailFilterCategoryViewModel(
         public fun showNativeAlert(text: String)
 
         public fun navigate(structure: ScreenStructure)
+
+        public fun navigateBack()
     }
 
     private data class ViewModelState(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* **改善:** メールフィルターカテゴリ設定画面でのナビゲーション機能を改善しました。フィルター削除後およびバック ボタン押下時に戻る操作が適切に動作するようになりました。戻る操作ができない場合は、設定画面へ自動的に遷移します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->