### PR TITLE
メールカテゴリフィルタ一覧画面で情報が更新されない問題を修正

### DIFF
--- a/backend/app/interfaces/src/jvmMain/kotlin/net/matsudamper/money/backend/app/interfaces/MailFilterRepository.kt
+++ b/backend/app/interfaces/src/jvmMain/kotlin/net/matsudamper/money/backend/app/interfaces/MailFilterRepository.kt
@@ -25,6 +25,7 @@ interface MailFilterRepository {
         sortType: SortType,
         userId: UserId,
         cursor: MailFilterCursor?,
+        size: Int,
     ): Result<MailFiltersResult>
 
     fun getConditions(

--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/user/UserResolverImpl.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/user/UserResolverImpl.kt
@@ -205,7 +205,7 @@ class UserResolverImpl : UserResolver {
                 cursor = query.cursor?.let {
                     ImportedMailCategoryFiltersCursor.fromString(it)
                 },
-                size = query.size,
+                size = query.size ?: 10,
             ).onFailure {
                 it.printStackTrace()
             }.getOrNull() ?: return@otelThenApplyAsync null

--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/user/UserResolverImpl.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/user/UserResolverImpl.kt
@@ -205,6 +205,7 @@ class UserResolverImpl : UserResolver {
                 cursor = query.cursor?.let {
                     ImportedMailCategoryFiltersCursor.fromString(it)
                 },
+                size = query.size,
             ).onFailure {
                 it.printStackTrace()
             }.getOrNull() ?: return@otelThenApplyAsync null

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMailFilterRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMailFilterRepository.kt
@@ -79,6 +79,7 @@ class DbMailFilterRepository(
         sortType: MailFilterRepository.SortType,
         userId: UserId,
         cursor: MailFilterRepository.MailFilterCursor?,
+        size: Int,
     ): Result<MailFilterRepository.MailFiltersResult> {
         return dbConnection.use {
             runCatching {
@@ -123,6 +124,7 @@ class DbMailFilterRepository(
                         },
                         filters.CATEGORY_MAIL_FILTER_ID.asc(),
                     )
+                    .limit(size)
                     .fetch()
                     .map { mapResult(it) }
 

--- a/backend/graphql/src/commonMain/resources/graphql/imported_mail_category_filter.graphqls
+++ b/backend/graphql/src/commonMain/resources/graphql/imported_mail_category_filter.graphqls
@@ -1,4 +1,5 @@
 input ImportedMailCategoryFiltersQuery {
+    size: Int!
     isAsc: Boolean!
     cursor: String
     sortType: ImportedMailCategoryFiltersSortType

--- a/backend/graphql/src/commonMain/resources/graphql/imported_mail_category_filter.graphqls
+++ b/backend/graphql/src/commonMain/resources/graphql/imported_mail_category_filter.graphqls
@@ -1,5 +1,5 @@
 input ImportedMailCategoryFiltersQuery {
-    size: Int!
+    size: Int
     isAsc: Boolean!
     cursor: String
     sortType: ImportedMailCategoryFiltersSortType

--- a/frontend/common/feature/uploader/src/commonMain/kotlin/net/matsudamper/money/frontend/common/feature/uploader/ImageUploadRoomDatabase.kt
+++ b/frontend/common/feature/uploader/src/commonMain/kotlin/net/matsudamper/money/frontend/common/feature/uploader/ImageUploadRoomDatabase.kt
@@ -26,6 +26,14 @@ internal abstract class ImageUploadRoomDatabase : RoomDatabase() {
         }
         val MIGRATION_3_4 = object : Migration(3, 4) {
             override suspend fun migrate(connection: SQLiteConnection) {
+                // MIGRATION_1_2を経由せずにVersion 3になったDBにはstackTraceカラムが存在しない可能性があるため、
+                // 追加を試みてすでに存在する場合のエラーは無視する
+                try {
+                    connection.execSQL("ALTER TABLE image_upload_queue ADD COLUMN stackTrace TEXT")
+                } catch (_: Exception) {
+                    // stackTraceカラムが既に存在する場合は無視
+                }
+
                 connection.execSQL(
                     """CREATE TABLE image_upload_queue_new (
                         |id TEXT NOT NULL PRIMARY KEY,

--- a/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
@@ -264,6 +264,8 @@ type ImportedMailCategoryFiltersConnection {
 }
 
 input ImportedMailCategoryFiltersQuery {
+  size: Int!
+
   isAsc: Boolean!
 
   cursor: String

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
@@ -1,8 +1,5 @@
 package net.matsudamper.money.frontend.common.ui.screen.root.settings
 
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -37,6 +34,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.ui.base.KakeBoTopAppBar
 import net.matsudamper.money.frontend.common.ui.base.KakeboScaffoldListener

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
@@ -1,5 +1,8 @@
 package net.matsudamper.money.frontend.common.ui.screen.root.settings
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -15,14 +18,21 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -66,6 +76,8 @@ public data class SettingMailCategoryFilterScreenUiState(
     @Immutable
     public interface LoadedEvent {
         public fun onClickAdd()
+
+        public fun onPullToRefresh()
     }
 
     @Immutable
@@ -163,6 +175,7 @@ public fun SettingMailCategoryFiltersScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LoadedContent(
     modifier: Modifier = Modifier,
@@ -173,7 +186,22 @@ private fun LoadedContent(
     val lazyListState = rememberLazyListState()
     val fabSize = 56.dp
     val fabPadding = 16.dp
-    Box(modifier = modifier) {
+    val pullToRefreshState = rememberPullToRefreshState()
+    val coroutineScope = rememberCoroutineScope()
+    var isRefreshing by remember { mutableStateOf(false) }
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        modifier = modifier,
+        state = pullToRefreshState,
+        onRefresh = {
+            coroutineScope.launch {
+                isRefreshing = true
+                uiState.event.onPullToRefresh()
+                delay(1000)
+                isRefreshing = false
+            }
+        },
+    ) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize(),

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -63,6 +64,7 @@ public data class SettingMailCategoryFilterScreenUiState(
         public data class Loaded(
             val filters: ImmutableList<Item>,
             val isError: Boolean,
+            val loadToEnd: Boolean,
             val event: LoadedEvent,
         ) : LoadingState
     }
@@ -77,6 +79,8 @@ public data class SettingMailCategoryFilterScreenUiState(
         public fun onClickAdd()
 
         public fun onPullToRefresh()
+
+        public fun loadMore()
     }
 
     @Immutable
@@ -215,6 +219,21 @@ private fun LoadedContent(
             items(uiState.filters) { item ->
                 SettingListMenuItemButton(onClick = { item.event.onClick() }) {
                     Text(item.title)
+                }
+            }
+            if (uiState.loadToEnd.not()) {
+                item {
+                    LaunchedEffect(Unit) {
+                        uiState.event.loadMore()
+                    }
+                    Box(
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(vertical = 12.dp),
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
                 }
             }
         }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/SettingMailCategoryFilterScreen.kt
@@ -27,16 +27,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.ui.base.KakeBoTopAppBar
 import net.matsudamper.money.frontend.common.ui.base.KakeboScaffoldListener
@@ -65,6 +60,7 @@ public data class SettingMailCategoryFilterScreenUiState(
             val filters: ImmutableList<Item>,
             val isError: Boolean,
             val loadToEnd: Boolean,
+            val isRefreshing: Boolean,
             val event: LoadedEvent,
         ) : LoadingState
     }
@@ -190,20 +186,11 @@ private fun LoadedContent(
     val fabSize = 56.dp
     val fabPadding = 16.dp
     val pullToRefreshState = rememberPullToRefreshState()
-    val coroutineScope = rememberCoroutineScope()
-    var isRefreshing by remember { mutableStateOf(false) }
     PullToRefreshBox(
-        isRefreshing = isRefreshing,
+        isRefreshing = uiState.isRefreshing,
         modifier = modifier,
         state = pullToRefreshState,
-        onRefresh = {
-            coroutineScope.launch {
-                isRefreshing = true
-                uiState.event.onPullToRefresh()
-                delay(1000)
-                isRefreshing = false
-            }
-        },
+        onRefresh = { uiState.event.onPullToRefresh() },
     ) {
         LazyColumn(
             modifier = Modifier

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -21,6 +21,15 @@ public class ImportedMailCategoryFilterScreenPagingModel(
     private val graphqlClient: GraphqlClient,
 ) : CommonViewModel(scopedObjectFeature) {
 
+    private val firstQuery = ImportedMailCategoryFiltersScreenPagingQuery(
+        query = ImportedMailCategoryFiltersQuery(
+            cursor = Optional.present(null),
+            isAsc = true,
+            size = 10,
+            sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
+        ),
+    )
+
     internal fun getFlow(): Flow<ApolloResponse<ImportedMailCategoryFiltersScreenPagingQuery.Data>> {
         return graphqlClient.apolloClient.query(firstQuery)
             .fetchPolicy(FetchPolicy.CacheFirst)
@@ -28,7 +37,9 @@ public class ImportedMailCategoryFilterScreenPagingModel(
     }
 
     internal suspend fun refresh(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
-        val response = fetch(cursor = null)
+        val response = graphqlClient.apolloClient.query(firstQuery)
+            .fetchPolicy(FetchPolicy.NetworkOnly)
+            .execute()
         val data = response.data
             ?: return UpdateOperationResponseResult.Error(NullPointerException("ApolloResponse.data is null"))
         graphqlClient.apolloClient.apolloStore.writeOperation(
@@ -40,22 +51,13 @@ public class ImportedMailCategoryFilterScreenPagingModel(
         return UpdateOperationResponseResult.Success(response)
     }
 
-    private val firstQuery = ImportedMailCategoryFiltersScreenPagingQuery(
-        query = ImportedMailCategoryFiltersQuery(
-            cursor = Optional.present(null),
-            isAsc = true,
-            size = 10,
-            sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
-        ),
-    )
-
     internal suspend fun fetch(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
         return graphqlClient.apolloClient.updateOperation(firstQuery) update@{ before ->
-            if (before == null) return@update success(fetch(cursor = null))
+            if (before == null) return@update success(fetchPage(cursor = null))
             if (before.user?.importedMailCategoryFilters?.isLast == true) return@update noHasMore()
 
             val cursor = before.user?.importedMailCategoryFilters?.cursor ?: return@update error()
-            val newData = fetch(cursor = cursor)
+            val newData = fetchPage(cursor = cursor)
             success(
                 newData.newBuilder()
                     .data(
@@ -78,7 +80,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
         }
     }
 
-    private suspend fun fetch(cursor: String?): ApolloResponse<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
+    private suspend fun fetchPage(cursor: String?): ApolloResponse<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
         return graphqlClient.apolloClient.query(
             query = ImportedMailCategoryFiltersScreenPagingQuery(
                 query = ImportedMailCategoryFiltersQuery(
@@ -88,8 +90,6 @@ public class ImportedMailCategoryFilterScreenPagingModel(
                     sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
                 ),
             ),
-        )
-            .fetchPolicy(FetchPolicy.NetworkOnly)
-            .execute()
+        ).execute()
     }
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -37,18 +37,20 @@ public class ImportedMailCategoryFilterScreenPagingModel(
     }
 
     internal suspend fun refresh(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
-        val response = graphqlClient.apolloClient.query(firstQuery)
-            .fetchPolicy(FetchPolicy.NetworkOnly)
-            .execute()
-        val data = response.data
-            ?: return UpdateOperationResponseResult.Error(NullPointerException("ApolloResponse.data is null"))
-        graphqlClient.apolloClient.apolloStore.writeOperation(
-            operation = firstQuery,
-            operationData = data,
-            customScalarAdapters = graphqlClient.apolloClient.customScalarAdapters,
-            publish = true,
-        )
-        return UpdateOperationResponseResult.Success(response)
+        return runCatching {
+            val response = graphqlClient.apolloClient.query(firstQuery)
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+            val data = response.data
+                ?: return UpdateOperationResponseResult.Error(NullPointerException("ApolloResponse.data is null"))
+            graphqlClient.apolloClient.apolloStore.writeOperation(
+                operation = firstQuery,
+                operationData = data,
+                customScalarAdapters = graphqlClient.apolloClient.customScalarAdapters,
+                publish = true,
+            )
+            UpdateOperationResponseResult.Success(response)
+        }.getOrElse { UpdateOperationResponseResult.Error(it) }
     }
 
     internal suspend fun fetch(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.Flow
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.api.CacheKey
 import com.apollographql.apollo.cache.normalized.apolloStore
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.apollographql.apollo.cache.normalized.watch
@@ -28,8 +27,17 @@ public class ImportedMailCategoryFilterScreenPagingModel(
             .watch()
     }
 
-    internal fun clear() {
-        graphqlClient.apolloClient.apolloStore.remove(CacheKey(firstQuery.name()))
+    internal suspend fun refresh(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
+        val response = fetch(cursor = null)
+        val data = response.data
+            ?: return UpdateOperationResponseResult.Error(NullPointerException("ApolloResponse.data is null"))
+        graphqlClient.apolloClient.apolloStore.writeOperation(
+            operation = firstQuery,
+            operationData = data,
+            customScalarAdapters = graphqlClient.apolloClient.customScalarAdapters,
+            publish = true,
+        )
+        return UpdateOperationResponseResult.Success(response)
     }
 
     private val firstQuery = ImportedMailCategoryFiltersScreenPagingQuery(

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -49,7 +49,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
             val cursor = before.user?.importedMailCategoryFilters?.cursor ?: return@update error()
             val newData = fetch(cursor = cursor)
             success(
-                fetch(cursor).newBuilder()
+                newData.newBuilder()
                     .data(
                         data = before.copy(
                             user = before.user?.copy(

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -24,7 +24,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
 
     internal fun getFlow(): Flow<ApolloResponse<ImportedMailCategoryFiltersScreenPagingQuery.Data>> {
         return graphqlClient.apolloClient.query(firstQuery)
-            .fetchPolicy(FetchPolicy.CacheOnly)
+            .fetchPolicy(FetchPolicy.CacheFirst)
             .watch()
     }
 
@@ -36,6 +36,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
         query = ImportedMailCategoryFiltersQuery(
             cursor = Optional.present(null),
             isAsc = true,
+            size = 10,
             sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
         ),
     )
@@ -75,6 +76,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
                 query = ImportedMailCategoryFiltersQuery(
                     cursor = Optional.present(cursor),
                     isAsc = true,
+                    size = 10,
                     sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
                 ),
             ),

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -88,6 +88,8 @@ public class ImportedMailCategoryFilterScreenPagingModel(
                     sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
                 ),
             ),
-        ).execute()
+        )
+            .fetchPolicy(FetchPolicy.NetworkOnly)
+            .execute()
     }
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
@@ -126,7 +126,7 @@ public class SettingMailCategoryFiltersViewModel(
                                 is UpdateOperationResponseResult.NoHasMore -> false
                                 null -> false
                                 is UpdateOperationResponseResult.Success -> {
-                                    it.result.data?.user?.importedMailCategoryFilters != null
+                                    it.result.data?.user?.importedMailCategoryFilters == null
                                 }
                             },
                             event = loadedEvent,

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
@@ -32,6 +32,10 @@ public class SettingMailCategoryFiltersViewModel(
     public val eventHandler: EventHandler<Event> = eventSender.asHandler()
 
     private val loadedEvent = object : SettingMailCategoryFilterScreenUiState.LoadedEvent {
+        override fun loadMore() {
+            listFetch()
+        }
+
         override fun onPullToRefresh() {
             pagingModel.clear()
             listFetch()
@@ -129,6 +133,7 @@ public class SettingMailCategoryFiltersViewModel(
                                     it.result.data?.user?.importedMailCategoryFilters == null
                                 }
                             },
+                            loadToEnd = viewModelState.apolloResponseStates?.data?.user?.importedMailCategoryFilters?.isLast == true,
                             event = loadedEvent,
                         )
                     }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
@@ -38,9 +38,10 @@ public class SettingMailCategoryFiltersViewModel(
 
         override fun onPullToRefresh() {
             viewModelScope.launch {
+                viewModelStateFlow.update { it.copy(isRefreshing = true) }
                 val result = pagingModel.refresh()
                 viewModelStateFlow.update {
-                    it.copy(lastLoadingState = result)
+                    it.copy(lastLoadingState = result, isRefreshing = false)
                 }
             }
         }
@@ -140,6 +141,7 @@ public class SettingMailCategoryFiltersViewModel(
                                 }
                             },
                             loadToEnd = viewModelState.apolloResponseStates?.data?.user?.importedMailCategoryFilters?.isLast == true,
+                            isRefreshing = viewModelState.isRefreshing,
                             event = loadedEvent,
                         )
                     }
@@ -200,5 +202,6 @@ public class SettingMailCategoryFiltersViewModel(
         val lastLoadingState: UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data>? = null,
         val textInputDialog: SettingMailCategoryFilterScreenUiState.TextInput? = null,
         val isLoading: Boolean = true,
+        val isRefreshing: Boolean = false,
     )
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
@@ -37,8 +37,12 @@ public class SettingMailCategoryFiltersViewModel(
         }
 
         override fun onPullToRefresh() {
-            pagingModel.clear()
-            listFetch()
+            viewModelScope.launch {
+                val result = pagingModel.refresh()
+                viewModelStateFlow.update {
+                    it.copy(lastLoadingState = result)
+                }
+            }
         }
 
         override fun onClickAdd() {
@@ -57,8 +61,10 @@ public class SettingMailCategoryFiltersViewModel(
                         runCatching {
                             api.addFilter(text)
                         }.onSuccess {
-                            pagingModel.clear()
-                            listFetch()
+                            val result = pagingModel.refresh()
+                            viewModelStateFlow.update {
+                                it.copy(lastLoadingState = result)
+                            }
                         }.onFailure {
                             it.printStackTrace()
                         }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
@@ -32,6 +32,11 @@ public class SettingMailCategoryFiltersViewModel(
     public val eventHandler: EventHandler<Event> = eventSender.asHandler()
 
     private val loadedEvent = object : SettingMailCategoryFilterScreenUiState.LoadedEvent {
+        override fun onPullToRefresh() {
+            pagingModel.clear()
+            listFetch()
+        }
+
         override fun onClickAdd() {
             viewModelStateFlow.update { viewModelState ->
                 viewModelState.copy(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * メール分類フィルター画面に「プルで更新」と「スクロールで続き読み込み（自動ページネーション）」を追加しました
  * 一括取得サイズの指定（ページサイズ）を導入し、デフォルトで10件ずつ取得します
  * 読み込み中インジケータと末尾の遅延読み込みトリガーを追加しました
  * キャッシュ優先の取得→刷新時はネットワークから再取得してキャッシュを書き戻す動作を導入しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->