### PR TITLE
カテゴリの削除機能を実装

### DIFF
--- a/.claude/skills/download-graphql-schema/SKILL.md
+++ b/.claude/skills/download-graphql-schema/SKILL.md
@@ -37,13 +37,16 @@ description: Guide for updating the frontend GraphQL schema by downloading it fr
 ./gradlew :backend:assemble
 ```
 
-実行可能スクリプトが `backend/build/bin/backend` に生成される。
+実行可能スクリプトが `backend/build/install/backend/bin/backend` に生成される。
 
 ### 2. バックエンドをバックグラウンドで起動する
 
+`run_in_background: true` で起動し、完了通知を待たずに次のステップへ進む。
+
 ```shell
-env $(cat schema_update_local.env | grep -v '^#' | xargs) ./backend/build/bin/backend &
+env $(cat schema_update_local.env | grep -v '^#' | xargs) ./backend/build/install/backend/bin/backend &
 BACKEND_PID=$!
+echo "PID: $BACKEND_PID"
 ```
 
 `schema_update_local.env` の内容：
@@ -55,15 +58,15 @@ BACKEND_PID=$!
 | `IS_DEBUG` | `true` | イントロスペクションを有効化（必須） |
 | `DB_*` | ダミー値 | DBには接続しないが変数が必要    |
 
-### 3. バックエンドの起動を待つ
+### 3. バックエンドの起動を確認する
+
+固定の sleep 後にヘルスチェックする（無限ループは使わない）。
 
 ```shell
-until curl -sf http://localhost/healthz > /dev/null 2>&1; do
-  sleep 1
-done
+sleep 8 && curl -sf http://localhost/healthz; echo "exit: $?"
 ```
 
-ヘルスチェックが成功するまで待機する（`/healthz` エンドポイントが `ok` を返せば準備完了）。
+`exit: 0` が返れば準備完了。失敗した場合はさらに数秒待ってから再実行する。
 
 ### 4. スキーマをダウンロードする
 

--- a/backend/app/interfaces/src/jvmMain/kotlin/net/matsudamper/money/backend/app/interfaces/MoneyUsageCategoryRepository.kt
+++ b/backend/app/interfaces/src/jvmMain/kotlin/net/matsudamper/money/backend/app/interfaces/MoneyUsageCategoryRepository.kt
@@ -23,6 +23,11 @@ interface MoneyUsageCategoryRepository {
         color: String?,
     ): Boolean
 
+    fun deleteCategory(
+        userId: UserId,
+        categoryId: MoneyUsageCategoryId,
+    ): Boolean
+
     data class CategoryResult(
         val userId: UserId,
         val moneyUsageCategoryId: MoneyUsageCategoryId,

--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/mutation/UserMutationResolverImpl.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/mutation/UserMutationResolverImpl.kt
@@ -479,6 +479,28 @@ class UserMutationResolverImpl : UserMutationResolver {
         }.toDataFetcher()
     }
 
+    override fun deleteCategory(
+        userMutation: QlUserMutation,
+        id: MoneyUsageCategoryId,
+        env: DataFetchingEnvironment,
+    ): CompletionStage<DataFetcherResult<Boolean>> {
+        val context = env.graphQlContext.get<GraphQlContext>(GraphQlContext::class.java.name)
+        val userId = context.verifyUserSessionAndGetUserId()
+
+        return otelSupplyAsync {
+            val result = context.diContainer.createMoneyUsageCategoryRepository()
+                .deleteCategory(
+                    userId = userId,
+                    categoryId = id,
+                )
+            if (result) {
+                true
+            } else {
+                throw IllegalStateException("delete category failed")
+            }
+        }.toDataFetcher()
+    }
+
     override fun addImportedMailCategoryFilter(
         userMutation: QlUserMutation,
         input: QlAddImportedMailCategoryFilterInput,

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMailFilterRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMailFilterRepository.kt
@@ -106,7 +106,19 @@ class DbMailFilterRepository(
         return dbConnection.use {
             runCatching {
                 val result = DSL.using(it)
-                    .selectFrom(filters)
+                    .select(
+                        filters.CATEGORY_MAIL_FILTER_ID,
+                        filters.USER_ID,
+                        filters.TITLE,
+                        subCategories.MONEY_USAGE_SUB_CATEGORY_ID,
+                        filters.CATEGORY_MAIL_FILTER_CONDITION_OPERATOR_TYPE_ID,
+                        filters.ORDER_NUMBER,
+                    )
+                    .from(filters)
+                    .leftJoin(subCategories).on(
+                        subCategories.MONEY_USAGE_SUB_CATEGORY_ID.eq(filters.MONEY_USAGE_SUB_CATEGORY_ID)
+                            .and(subCategories.USER_ID.eq(userId.value)),
+                    )
                     .where(
                         DSL.value(true)
                             .and(filters.USER_ID.eq(userId.value))
@@ -148,7 +160,19 @@ class DbMailFilterRepository(
                     )
                     .limit(size)
                     .fetch()
-                    .map { mapResult(it) }
+                    .map { record ->
+                        MailFilterRepository.MailFilter(
+                            importedMailCategoryFilterId = ImportedMailCategoryFilterId(record.get(filters.CATEGORY_MAIL_FILTER_ID)!!),
+                            userId = UserId(record.get(filters.USER_ID)!!),
+                            title = record.get(filters.TITLE)!!,
+                            moneyUsageSubCategoryId = record.get(subCategories.MONEY_USAGE_SUB_CATEGORY_ID)
+                                ?.let { MoneyUsageSubCategoryId(it) },
+                            operator = DbImportedMailFilterCategoryConditionOperator.fromDbValue(
+                                record.get(filters.CATEGORY_MAIL_FILTER_CONDITION_OPERATOR_TYPE_ID)!!,
+                            ).toLogicValue(),
+                            orderNumber = record.get(filters.ORDER_NUMBER)!!,
+                        )
+                    }
 
                 val lastResult = result.lastOrNull()
                 MailFilterRepository.MailFiltersResult(
@@ -447,7 +471,19 @@ class DbMailFilterRepository(
         return runCatching {
             dbConnection.use {
                 DSL.using(it)
-                    .selectFrom(filters)
+                    .select(
+                        filters.CATEGORY_MAIL_FILTER_ID,
+                        filters.USER_ID,
+                        filters.TITLE,
+                        subCategories.MONEY_USAGE_SUB_CATEGORY_ID,
+                        filters.CATEGORY_MAIL_FILTER_CONDITION_OPERATOR_TYPE_ID,
+                        filters.ORDER_NUMBER,
+                    )
+                    .from(filters)
+                    .leftJoin(subCategories).on(
+                        subCategories.MONEY_USAGE_SUB_CATEGORY_ID.eq(filters.MONEY_USAGE_SUB_CATEGORY_ID)
+                            .and(subCategories.USER_ID.eq(userId.value)),
+                    )
                     .where(
                         DSL.value(true)
                             .and(filters.USER_ID.eq(userId.value)),
@@ -455,7 +491,17 @@ class DbMailFilterRepository(
                     .orderBy(filters.ORDER_NUMBER.asc())
                     .fetch()
                     .map { record ->
-                        mapResult(record)
+                        MailFilterRepository.MailFilter(
+                            importedMailCategoryFilterId = ImportedMailCategoryFilterId(record.get(filters.CATEGORY_MAIL_FILTER_ID)!!),
+                            userId = UserId(record.get(filters.USER_ID)!!),
+                            title = record.get(filters.TITLE)!!,
+                            moneyUsageSubCategoryId = record.get(subCategories.MONEY_USAGE_SUB_CATEGORY_ID)
+                                ?.let { MoneyUsageSubCategoryId(it) },
+                            operator = DbImportedMailFilterCategoryConditionOperator.fromDbValue(
+                                record.get(filters.CATEGORY_MAIL_FILTER_CONDITION_OPERATOR_TYPE_ID)!!,
+                            ).toLogicValue(),
+                            orderNumber = record.get(filters.ORDER_NUMBER)!!,
+                        )
                     }
             }
         }.onFailure {

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMailFilterRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMailFilterRepository.kt
@@ -60,15 +60,37 @@ class DbMailFilterRepository(
         return dbConnection.use {
             runCatching {
                 DSL.using(it)
-                    .selectFrom(filters)
+                    .select(
+                        filters.CATEGORY_MAIL_FILTER_ID,
+                        filters.USER_ID,
+                        filters.TITLE,
+                        subCategories.MONEY_USAGE_SUB_CATEGORY_ID,
+                        filters.CATEGORY_MAIL_FILTER_CONDITION_OPERATOR_TYPE_ID,
+                        filters.ORDER_NUMBER,
+                    )
+                    .from(filters)
+                    .leftJoin(subCategories).on(
+                        subCategories.MONEY_USAGE_SUB_CATEGORY_ID.eq(filters.MONEY_USAGE_SUB_CATEGORY_ID)
+                            .and(subCategories.USER_ID.eq(userId.value)),
+                    )
                     .where(
                         DSL.value(true)
                             .and(filters.USER_ID.eq(userId.value))
                             .and(filters.CATEGORY_MAIL_FILTER_ID.`in`(categoryFilterIds.map { it.id })),
                     )
                     .fetch()
-                    .map {
-                        mapResult(it)
+                    .map { record ->
+                        MailFilterRepository.MailFilter(
+                            importedMailCategoryFilterId = ImportedMailCategoryFilterId(record.get(filters.CATEGORY_MAIL_FILTER_ID)!!),
+                            userId = UserId(record.get(filters.USER_ID)!!),
+                            title = record.get(filters.TITLE)!!,
+                            moneyUsageSubCategoryId = record.get(subCategories.MONEY_USAGE_SUB_CATEGORY_ID)
+                                ?.let { MoneyUsageSubCategoryId(it) },
+                            operator = DbImportedMailFilterCategoryConditionOperator.fromDbValue(
+                                record.get(filters.CATEGORY_MAIL_FILTER_CONDITION_OPERATOR_TYPE_ID)!!,
+                            ).toLogicValue(),
+                            orderNumber = record.get(filters.ORDER_NUMBER)!!,
+                        )
                     }
             }
         }

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageCategoryRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageCategoryRepository.kt
@@ -7,6 +7,7 @@ import net.matsudamper.money.db.schema.tables.JMoneyUsageSubCategories
 import net.matsudamper.money.db.schema.tables.records.JMoneyUsageCategoriesRecord
 import net.matsudamper.money.element.MoneyUsageCategoryId
 import net.matsudamper.money.element.UserId
+import org.jooq.TransactionalRunnable
 import org.jooq.impl.DSL
 import org.jooq.kotlin.and
 
@@ -135,23 +136,31 @@ class DbMoneyUsageCategoryRepository : MoneyUsageCategoryRepository {
         userId: UserId,
         categoryId: MoneyUsageCategoryId,
     ): Boolean {
-        return DbConnectionImpl.use { connection ->
-            val context = DSL.using(connection)
-            context.deleteFrom(subCategories)
-                .where(
-                    DSL.value(true)
-                        .and(subCategories.USER_ID.eq(userId.value))
-                        .and(subCategories.MONEY_USAGE_CATEGORY_ID.eq(categoryId.value)),
+        return runCatching {
+            DbConnectionImpl.use { connection ->
+                DSL.using(connection).transaction(
+                    TransactionalRunnable { config ->
+                        val ctx = DSL.using(config)
+                        ctx.deleteFrom(subCategories)
+                            .where(
+                                DSL.value(true)
+                                    .and(subCategories.USER_ID.eq(userId.value))
+                                    .and(subCategories.MONEY_USAGE_CATEGORY_ID.eq(categoryId.value)),
+                            )
+                            .execute()
+                        val deleted = ctx.deleteFrom(categories)
+                            .where(
+                                DSL.value(true)
+                                    .and(categories.USER_ID.eq(userId.value))
+                                    .and(categories.MONEY_USAGE_CATEGORY_ID.eq(categoryId.value)),
+                            )
+                            .limit(1)
+                            .execute()
+                        if (deleted < 1) throw IllegalStateException("削除対象のカテゴリが見つかりませんでした")
+                    },
                 )
-                .execute()
-            context.deleteFrom(categories)
-                .where(
-                    DSL.value(true)
-                        .and(categories.USER_ID.eq(userId.value))
-                        .and(categories.MONEY_USAGE_CATEGORY_ID.eq(categoryId.value)),
-                )
-                .limit(1)
-                .execute()
-        } >= 1
+            }
+            true
+        }.getOrDefault(false)
     }
 }

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageCategoryRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageCategoryRepository.kt
@@ -3,6 +3,7 @@ package net.matsudamper.money.backend.datasource.db.repository
 import net.matsudamper.money.backend.app.interfaces.MoneyUsageCategoryRepository
 import net.matsudamper.money.backend.datasource.db.DbConnectionImpl
 import net.matsudamper.money.db.schema.tables.JMoneyUsageCategories
+import net.matsudamper.money.db.schema.tables.JMoneyUsageSubCategories
 import net.matsudamper.money.db.schema.tables.records.JMoneyUsageCategoriesRecord
 import net.matsudamper.money.element.MoneyUsageCategoryId
 import net.matsudamper.money.element.UserId
@@ -11,6 +12,7 @@ import org.jooq.kotlin.and
 
 class DbMoneyUsageCategoryRepository : MoneyUsageCategoryRepository {
     private val categories = JMoneyUsageCategories.MONEY_USAGE_CATEGORIES
+    private val subCategories = JMoneyUsageSubCategories.MONEY_USAGE_SUB_CATEGORIES
 
     override fun addCategory(
         userId: UserId,
@@ -127,5 +129,29 @@ class DbMoneyUsageCategoryRepository : MoneyUsageCategoryRepository {
                 .limit(1)
                 .execute() >= 1
         }
+    }
+
+    override fun deleteCategory(
+        userId: UserId,
+        categoryId: MoneyUsageCategoryId,
+    ): Boolean {
+        return DbConnectionImpl.use { connection ->
+            val context = DSL.using(connection)
+            context.deleteFrom(subCategories)
+                .where(
+                    DSL.value(true)
+                        .and(subCategories.USER_ID.eq(userId.value))
+                        .and(subCategories.MONEY_USAGE_CATEGORY_ID.eq(categoryId.value)),
+                )
+                .execute()
+            context.deleteFrom(categories)
+                .where(
+                    DSL.value(true)
+                        .and(categories.USER_ID.eq(userId.value))
+                        .and(categories.MONEY_USAGE_CATEGORY_ID.eq(categoryId.value)),
+                )
+                .limit(1)
+                .execute()
+        } >= 1
     }
 }

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsagePresetRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsagePresetRepository.kt
@@ -18,12 +18,33 @@ class DbMoneyUsagePresetRepository : MoneyUsagePresetRepository {
     override fun getPresets(userId: UserId): List<MoneyUsagePresetRepository.PresetResult> {
         return DbConnectionImpl.use { connection ->
             DSL.using(connection)
-                .selectFrom(presets)
+                .select(
+                    presets.MONEY_USAGE_PRESET_ID,
+                    presets.USER_ID,
+                    presets.NAME,
+                    subCategories.MONEY_USAGE_SUB_CATEGORY_ID,
+                    presets.AMOUNT,
+                    presets.DESCRIPTION,
+                    presets.ORDER_NUMBER,
+                )
+                .from(presets)
+                .leftJoin(subCategories).on(
+                    subCategories.MONEY_USAGE_SUB_CATEGORY_ID.eq(presets.MONEY_USAGE_SUB_CATEGORY_ID)
+                        .and(subCategories.USER_ID.eq(userId.value)),
+                )
                 .where(presets.USER_ID.eq(userId.value))
                 .orderBy(presets.ORDER_NUMBER.asc(), presets.MONEY_USAGE_PRESET_ID.asc())
                 .fetch()
                 .map { record ->
-                    record.toPresetResult()
+                    MoneyUsagePresetRepository.PresetResult(
+                        presetId = MoneyUsagePresetId(record.get(presets.MONEY_USAGE_PRESET_ID)!!),
+                        userId = UserId(record.get(presets.USER_ID)!!),
+                        name = record.get(presets.NAME)!!,
+                        subCategoryId = record.get(subCategories.MONEY_USAGE_SUB_CATEGORY_ID)
+                            ?.let { MoneyUsageSubCategoryId(it) },
+                        amount = record.get(presets.AMOUNT),
+                        description = record.get(presets.DESCRIPTION),
+                    )
                 }
         }
     }

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageRepository.kt
@@ -3,7 +3,6 @@ package net.matsudamper.money.backend.datasource.db.repository
 import java.lang.IllegalStateException
 import java.time.LocalDateTime
 import net.matsudamper.money.backend.app.interfaces.MoneyUsageRepository
-import net.matsudamper.money.backend.app.interfaces.MoneyUsageRepository.OrderType
 import net.matsudamper.money.backend.base.TraceLogger
 import net.matsudamper.money.backend.datasource.db.DbConnectionImpl
 import net.matsudamper.money.db.schema.tables.JMoneyUsageImagesRelation
@@ -127,9 +126,11 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
                         throw IllegalStateException("failed to insert")
                     }
 
+                    val result = results.first()
                     val usage = mapMoneyUsage(
-                        result = results.first(),
+                        result = result,
                         imageIds = imageIds,
+                        subCategoryId = result.get(jUsage.MONEY_USAGE_SUB_CATEGORY_ID)?.let { MoneyUsageSubCategoryId(it) },
                     )
                     replaceMoneyUsageImages(
                         connection = connection,
@@ -330,11 +331,15 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
                         jUsage.USER_ID,
                         jUsage.TITLE,
                         jUsage.DESCRIPTION,
-                        jUsage.MONEY_USAGE_SUB_CATEGORY_ID,
+                        jSubCategory.MONEY_USAGE_SUB_CATEGORY_ID,
                         jUsage.DATETIME,
                         jUsage.AMOUNT,
                     )
                     .from(jUsage)
+                    .leftJoin(jSubCategory).on(
+                        jSubCategory.MONEY_USAGE_SUB_CATEGORY_ID.eq(jUsage.MONEY_USAGE_SUB_CATEGORY_ID)
+                            .and(jSubCategory.USER_ID.eq(userId.value)),
+                    )
                     .where(
                         DSL.value(true)
                             .and(jUsage.USER_ID.eq(userId.value))
@@ -347,6 +352,8 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
                     mapMoneyUsage(
                         result = result,
                         imageIds = imageIdsMap[usageId].orEmpty(),
+                        subCategoryId = result.get(jSubCategory.MONEY_USAGE_SUB_CATEGORY_ID)
+                            ?.let { MoneyUsageSubCategoryId(it) },
                     )
                 }
             }
@@ -356,13 +363,14 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
     private fun mapMoneyUsage(
         result: Record,
         imageIds: List<ImageId>,
+        subCategoryId: MoneyUsageSubCategoryId?,
     ): MoneyUsageRepository.Usage {
         return MoneyUsageRepository.Usage(
             id = MoneyUsageId(result.get(jUsage.MONEY_USAGE_ID)!!),
             userId = UserId(result.get(jUsage.USER_ID)!!),
             title = result.get(jUsage.TITLE)!!,
             description = result.get(jUsage.DESCRIPTION)!!,
-            subCategoryId = result.get(jUsage.MONEY_USAGE_SUB_CATEGORY_ID)?.let { MoneyUsageSubCategoryId(it) },
+            subCategoryId = subCategoryId,
             date = result.get(jUsage.DATETIME)!!,
             amount = result.get(jUsage.AMOUNT)!!,
             imageIds = imageIds,
@@ -381,7 +389,7 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
                         jUsage.USER_ID,
                         jUsage.TITLE,
                         jUsage.DESCRIPTION,
-                        jUsage.MONEY_USAGE_SUB_CATEGORY_ID,
+                        jSubCategory.MONEY_USAGE_SUB_CATEGORY_ID,
                         jUsage.DATETIME,
                         jUsage.AMOUNT,
                     )
@@ -389,6 +397,10 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
                     .join(jUsage).on(
                         jRelation.MONEY_USAGE_ID.eq(jUsage.MONEY_USAGE_ID)
                             .and(jUsage.USER_ID.eq(userId.value)),
+                    )
+                    .leftJoin(jSubCategory).on(
+                        jSubCategory.MONEY_USAGE_SUB_CATEGORY_ID.eq(jUsage.MONEY_USAGE_SUB_CATEGORY_ID)
+                            .and(jSubCategory.USER_ID.eq(userId.value)),
                     )
                     .where(
                         DSL.value(true)
@@ -402,11 +414,13 @@ class DbMoneyUsageRepository : MoneyUsageRepository {
                     userId = userId,
                     usageIds = usageIds,
                 )
-                results.map {
-                    val usageId = MoneyUsageId(it.get(jUsage.MONEY_USAGE_ID)!!)
+                results.map { result ->
+                    val usageId = MoneyUsageId(result.get(jUsage.MONEY_USAGE_ID)!!)
                     mapMoneyUsage(
-                        result = it,
+                        result = result,
                         imageIds = imageIdsMap[usageId].orEmpty(),
+                        subCategoryId = result.get(jSubCategory.MONEY_USAGE_SUB_CATEGORY_ID)
+                            ?.let { MoneyUsageSubCategoryId(it) },
                     )
                 }
             }

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageSubCategoryRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbMoneyUsageSubCategoryRepository.kt
@@ -4,7 +4,7 @@ import net.matsudamper.money.backend.app.interfaces.MoneyUsageSubCategoryReposit
 import net.matsudamper.money.backend.datasource.db.DbConnectionImpl
 import net.matsudamper.money.db.schema.tables.JMoneyUsageCategories
 import net.matsudamper.money.db.schema.tables.JMoneyUsageSubCategories
-import net.matsudamper.money.db.schema.tables.records.JMoneyUsageCategoriesRecord
+import net.matsudamper.money.db.schema.tables.records.JMoneyUsageSubCategoriesRecord
 import net.matsudamper.money.element.MoneyUsageCategoryId
 import net.matsudamper.money.element.MoneyUsageSubCategoryId
 import net.matsudamper.money.element.UserId
@@ -44,7 +44,7 @@ class DbMoneyUsageSubCategoryRepository : MoneyUsageSubCategoryRepository {
                 val record = DSL.using(connection)
                     .insertInto(subCategories)
                     .set(
-                        JMoneyUsageCategoriesRecord(
+                        JMoneyUsageSubCategoriesRecord(
                             userId = userId.value,
                             name = name,
                             moneyUsageCategoryId = categoryId.value,

--- a/backend/graphql/src/commonMain/resources/graphql/user_mutation.graphqls
+++ b/backend/graphql/src/commonMain/resources/graphql/user_mutation.graphqls
@@ -19,6 +19,7 @@ type UserMutation {
     addSubCategory(input: AddSubCategoryInput!) : AddSubCategoryResult!
     updateSubCategory(id: MoneyUsageSubCategoryId!, query: UpdateSubCategoryQuery!): MoneyUsageSubCategory!
     deleteSubCategory(id: MoneyUsageSubCategoryId!): Boolean!
+    deleteCategory(id: MoneyUsageCategoryId!): Boolean!
 
     addImportedMailCategoryFilter(input: AddImportedMailCategoryFilterInput!): ImportedMailCategoryFilter
     updateImportedMailCategoryFilter(input: UpdateImportedMailCategoryFilterInput!): ImportedMailCategoryFilter

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/NotificationUsageCategoryFilterRepository.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/NotificationUsageCategoryFilterRepository.kt
@@ -30,7 +30,7 @@ internal class NotificationUsageCategoryFilterGraphqlRepository(
                 .query(
                     NotificationUsageCategoryFiltersQuery(
                         query = ImportedMailCategoryFiltersQuery(
-                            size = 1000,
+                            size = Optional.present(1000),
                             isAsc = true,
                             sortType = Optional.present(ImportedMailCategoryFiltersSortType.ORDER_NUMBER),
                         ),

--- a/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
@@ -264,7 +264,7 @@ type ImportedMailCategoryFiltersConnection {
 }
 
 input ImportedMailCategoryFiltersQuery {
-  size: Int!
+  size: Int
 
   isAsc: Boolean!
 
@@ -777,6 +777,8 @@ type UserMutation {
   updateSubCategory(id: MoneyUsageSubCategoryId!, query: UpdateSubCategoryQuery!): MoneyUsageSubCategory!
 
   deleteSubCategory(id: MoneyUsageSubCategoryId!): Boolean!
+
+  deleteCategory(id: MoneyUsageCategoryId!): Boolean!
 
   addImportedMailCategoryFilter(input: AddImportedMailCategoryFilterInput!): ImportedMailCategoryFilter
 

--- a/frontend/common/graphql/schema/src/commonMain/graphql/user_mutation.graphql
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/user_mutation.graphql
@@ -89,3 +89,9 @@ mutation DeleteSubCategory($id: MoneyUsageSubCategoryId!) {
         deleteSubCategory(id: $id)
     }
 }
+
+mutation DeleteCategory($id: MoneyUsageCategoryId!) {
+    userMutation {
+        deleteCategory(id: $id)
+    }
+}

--- a/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/ViewModelEventHandlers.kt
+++ b/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/ViewModelEventHandlers.kt
@@ -137,6 +137,9 @@ internal data class ViewModelEventHandlers(
         coroutineScope {
             handler.collect(
                 object : SettingCategoryViewModel.Event {
+                    override fun navigateToCategories() {
+                        navController.navigate(ScreenStructure.Root.Settings.Categories)
+                    }
                 },
             )
         }

--- a/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/ViewModelEventHandlers.kt
+++ b/frontend/common/root/src/commonMain/kotlin/net/matsudamper/money/ui/root/ViewModelEventHandlers.kt
@@ -138,7 +138,7 @@ internal data class ViewModelEventHandlers(
             handler.collect(
                 object : SettingCategoryViewModel.Event {
                     override fun navigateToCategories() {
-                        navController.navigate(ScreenStructure.Root.Settings.Categories)
+                        navController.navigateReplace(ScreenStructure.Root.Settings.Categories)
                     }
                 },
             )

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
@@ -55,6 +55,7 @@ import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.ui.base.KakeBoTopAppBar
 import net.matsudamper.money.frontend.common.ui.base.KakeboScaffoldListener
 import net.matsudamper.money.frontend.common.ui.base.RootScreenScaffold
+import net.matsudamper.money.frontend.common.ui.layout.AlertDialog
 import net.matsudamper.money.frontend.common.ui.layout.colorpicker.ColorPickerDialog
 import net.matsudamper.money.frontend.common.ui.layout.html.text.fullscreen.FullScreenTextInput
 
@@ -67,8 +68,16 @@ public data class SettingCategoryScreenUiState(
     val showCategoryNameChangeDialog: FullScreenInputDialog?,
     val showSubCategoryNameChangeDialog: FullScreenInputDialog?,
     val showColorPickerDialog: Boolean,
+    val confirmDialog: ConfirmDialog?,
     val kakeboScaffoldListener: KakeboScaffoldListener,
 ) {
+    public data class ConfirmDialog(
+        val title: String,
+        val description: String?,
+        val onConfirm: () -> Unit,
+        val onDismiss: () -> Unit,
+    )
+
     public data class FullScreenInputDialog(
         val initText: String,
         val event: Event,
@@ -118,6 +127,8 @@ public data class SettingCategoryScreenUiState(
         public fun onDismissColorPicker()
 
         public fun onColorSelected(color: Color)
+
+        public fun onClickDeleteCategory()
     }
 }
 
@@ -174,6 +185,20 @@ public fun SettingCategoryScreen(
             currentColor = uiState.categoryColor,
             onDismiss = { uiState.event.onDismissColorPicker() },
             onColorSelected = { color -> uiState.event.onColorSelected(color) },
+        )
+    }
+
+    uiState.confirmDialog?.also { confirmDialog ->
+        AlertDialog(
+            title = { Text(confirmDialog.title) },
+            description = confirmDialog.description?.let {
+                {
+                    Text(confirmDialog.description)
+                }
+            },
+            onClickPositive = { confirmDialog.onConfirm() },
+            onClickNegative = { confirmDialog.onDismiss() },
+            onDismissRequest = { confirmDialog.onDismiss() },
         )
     }
 
@@ -276,6 +301,9 @@ private fun LoadedContent(
                     onClickSubCategoryButton = {
                         uiState.event.onClickAddSubCategoryButton()
                     },
+                    onClickDeleteCategoryButton = {
+                        uiState.event.onClickDeleteCategory()
+                    },
                 )
             }
             item {
@@ -377,6 +405,7 @@ private fun HeaderSection(
     onClickChangeCategoryNameButton: () -> Unit,
     onClickChangeColorButton: () -> Unit,
     onClickSubCategoryButton: () -> Unit,
+    onClickDeleteCategoryButton: () -> Unit,
 ) {
     Row(
         modifier = modifier,
@@ -420,6 +449,13 @@ private fun HeaderSection(
                 ) {
                     Icon(Icons.Default.Add, contentDescription = null)
                     Text(text = "サブカテゴリーを追加")
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                OutlinedButton(
+                    modifier = Modifier,
+                    onClick = { onClickDeleteCategoryButton() },
+                ) {
+                    Text(text = "カテゴリーを削除")
                 }
             }
         }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
@@ -71,12 +71,15 @@ public data class SettingCategoryScreenUiState(
     val confirmDialog: ConfirmDialog?,
     val kakeboScaffoldListener: KakeboScaffoldListener,
 ) {
-    public data class ConfirmDialog(
-        val title: String,
-        val description: String?,
-        val onConfirm: () -> Unit,
-        val onDismiss: () -> Unit,
-    )
+    @Immutable
+    public interface ConfirmDialog {
+        public val title: String
+        public val description: String?
+
+        public fun onConfirm()
+
+        public fun onDismiss()
+    }
 
     public data class FullScreenInputDialog(
         val initText: String,
@@ -193,7 +196,7 @@ public fun SettingCategoryScreen(
             title = { Text(confirmDialog.title) },
             description = confirmDialog.description?.let {
                 {
-                    Text(confirmDialog.description)
+                    Text(it)
                 }
             },
             onClickPositive = { confirmDialog.onConfirm() },

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -25,7 +25,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
         query = ImportedMailCategoryFiltersQuery(
             cursor = Optional.present(null),
             isAsc = true,
-            size = 10,
+            size = Optional.present(10),
             sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
         ),
     )
@@ -88,7 +88,7 @@ public class ImportedMailCategoryFilterScreenPagingModel(
                 query = ImportedMailCategoryFiltersQuery(
                     cursor = Optional.present(cursor),
                     isAsc = true,
-                    size = 10,
+                    size = Optional.present(10),
                     sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
                 ),
             ),

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
@@ -188,9 +188,9 @@ public class SettingCategoryViewModel(
                                                 globalEventSender.send {
                                                     it.showSnackBar("削除しました")
                                                 }
-                                            }
-                                            viewModelEventSender.send {
-                                                it.navigateToCategories()
+                                                viewModelEventSender.send {
+                                                    it.navigateToCategories()
+                                                }
                                             }
                                         } else {
                                             launch {

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
@@ -163,14 +163,15 @@ public class SettingCategoryViewModel(
                 }
 
                 override fun onClickDeleteCategory() {
-                    val subCategoryCount = viewModelStateFlow.value.responseList
-                        .flatMap { it.nodes }
-                        .filterNot { it.id in viewModelStateFlow.value.deletedSubCategoryIds }
-                        .size
-                    val description = if (subCategoryCount > 0) {
-                        "${subCategoryCount}件のサブカテゴリーが紐づいています"
+                    val state = viewModelStateFlow.value
+                    val description = if (state.hasMoreSubCategories) {
+                        "100件以上のサブカテゴリーが紐づいています"
                     } else {
-                        null
+                        val subCategoryCount = state.responseList
+                            .flatMap { it.nodes }
+                            .filterNot { it.id in state.deletedSubCategoryIds }
+                            .size
+                        if (subCategoryCount > 0) "${subCategoryCount}件のサブカテゴリーが紐づいています" else null
                     }
                     viewModelStateFlow.update {
                         it.copy(
@@ -429,6 +430,7 @@ public class SettingCategoryViewModel(
                     isFirstLoading = false,
                     responseList = listOf(data),
                     deletedSubCategoryIds = listOf(),
+                    hasMoreSubCategories = data.cursor != null,
                 )
             }
         }
@@ -437,6 +439,7 @@ public class SettingCategoryViewModel(
     private data class ViewModelState(
         val isFirstLoading: Boolean,
         val responseList: List<CategorySettingScreenSubCategoriesPagingQuery.SubCategories>,
+        val hasMoreSubCategories: Boolean = false,
         val categoryInfo: CategorySettingScreenQuery.MoneyUsageCategory? = null,
         val showAddSubCategoryNameInput: Boolean = false,
         val showCategoryNameChangeInput: SettingCategoryScreenUiState.FullScreenInputDialog? = null,

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
@@ -174,10 +174,11 @@ public class SettingCategoryViewModel(
                     }
                     viewModelStateFlow.update {
                         it.copy(
-                            confirmDialog = SettingCategoryScreenUiState.ConfirmDialog(
-                                title = "このカテゴリを削除しますか",
-                                description = description,
-                                onConfirm = {
+                            confirmDialog = object : SettingCategoryScreenUiState.ConfirmDialog {
+                                override val title = "このカテゴリを削除しますか"
+                                override val description = description
+
+                                override fun onConfirm() {
                                     viewModelScope.launch {
                                         val isSuccess = api.deleteCategory(id = categoryId)
                                         viewModelStateFlow.update { state ->
@@ -200,13 +201,14 @@ public class SettingCategoryViewModel(
                                             }
                                         }
                                     }
-                                },
-                                onDismiss = {
+                                }
+
+                                override fun onDismiss() {
                                     viewModelStateFlow.update { state ->
                                         state.copy(confirmDialog = null)
                                     }
-                                },
-                            ),
+                                }
+                            },
                         )
                     }
                 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
@@ -161,12 +161,62 @@ public class SettingCategoryViewModel(
                         }
                     }
                 }
+
+                override fun onClickDeleteCategory() {
+                    val subCategoryCount = viewModelStateFlow.value.responseList
+                        .flatMap { it.nodes }
+                        .filterNot { it.id in viewModelStateFlow.value.deletedSubCategoryIds }
+                        .size
+                    val description = if (subCategoryCount > 0) {
+                        "${subCategoryCount}件のサブカテゴリーが紐づいています"
+                    } else {
+                        null
+                    }
+                    viewModelStateFlow.update {
+                        it.copy(
+                            confirmDialog = SettingCategoryScreenUiState.ConfirmDialog(
+                                title = "このカテゴリを削除しますか",
+                                description = description,
+                                onConfirm = {
+                                    viewModelScope.launch {
+                                        val isSuccess = api.deleteCategory(id = categoryId)
+                                        viewModelStateFlow.update { state ->
+                                            state.copy(confirmDialog = null)
+                                        }
+                                        if (isSuccess) {
+                                            launch {
+                                                globalEventSender.send {
+                                                    it.showSnackBar("削除しました")
+                                                }
+                                            }
+                                            viewModelEventSender.send {
+                                                it.navigateToCategories()
+                                            }
+                                        } else {
+                                            launch {
+                                                globalEventSender.send {
+                                                    it.showNativeNotification("削除に失敗しました")
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                onDismiss = {
+                                    viewModelStateFlow.update { state ->
+                                        state.copy(confirmDialog = null)
+                                    }
+                                },
+                            ),
+                        )
+                    }
+                }
             },
             loadingState = SettingCategoryScreenUiState.LoadingState.Loading,
             showCategoryNameInput = false,
             showCategoryNameChangeDialog = null,
             showSubCategoryNameChangeDialog = null,
             showColorPickerDialog = false,
+            confirmDialog = null,
             categoryName = "",
             categoryColor = null,
             kakeboScaffoldListener = object : KakeboScaffoldListener {
@@ -199,6 +249,7 @@ public class SettingCategoryViewModel(
                         showCategoryNameChangeDialog = viewModelState.showCategoryNameChangeInput,
                         showSubCategoryNameChangeDialog = viewModelState.showSubCategoryNameChangeInput,
                         showColorPickerDialog = viewModelState.showColorPickerDialog,
+                        confirmDialog = viewModelState.confirmDialog,
                         categoryName = viewModelState.categoryInfo?.name.orEmpty(),
                         categoryColor = viewModelState.categoryInfo?.color?.let(ColorUtil::parseHexColor),
                     )
@@ -390,7 +441,10 @@ public class SettingCategoryViewModel(
         val showSubCategoryNameChangeInput: SettingCategoryScreenUiState.FullScreenInputDialog? = null,
         val showColorPickerDialog: Boolean = false,
         val deletedSubCategoryIds: List<MoneyUsageSubCategoryId> = listOf(),
+        val confirmDialog: SettingCategoryScreenUiState.ConfirmDialog? = null,
     )
 
-    public interface Event
+    public interface Event {
+        public fun navigateToCategories()
+    }
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
@@ -165,7 +165,8 @@ public class SettingCategoryViewModel(
                 override fun onClickDeleteCategory() {
                     val state = viewModelStateFlow.value
                     val description = if (state.hasMoreSubCategories) {
-                        "100件以上のサブカテゴリーが紐づいています"
+                        val loadedCount = state.responseList.flatMap { it.nodes }.size
+                        "${loadedCount}件以上のサブカテゴリーが紐づいています"
                     } else {
                         val subCategoryCount = state.responseList
                             .flatMap { it.nodes }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingScreenCategoryApi.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingScreenCategoryApi.kt
@@ -15,6 +15,7 @@ import net.matsudamper.money.frontend.graphql.AddSubCategoryMutation
 import net.matsudamper.money.frontend.graphql.CategoriesSettingScreenCategoriesPagingQuery
 import net.matsudamper.money.frontend.graphql.CategorySettingScreenQuery
 import net.matsudamper.money.frontend.graphql.CategorySettingScreenSubCategoriesPagingQuery
+import net.matsudamper.money.frontend.graphql.DeleteCategoryMutation
 import net.matsudamper.money.frontend.graphql.DeleteSubCategoryMutation
 import net.matsudamper.money.frontend.graphql.UpdateCategoryMutation
 import net.matsudamper.money.frontend.graphql.UpdateSubCategoryMutation
@@ -154,6 +155,18 @@ public class SettingScreenCategoryApi(
             apolloClient
                 .mutation(
                     DeleteSubCategoryMutation(
+                        id = id,
+                    ),
+                )
+                .execute()
+        }.getOrNull()?.data?.userMutation != null
+    }
+
+    public suspend fun deleteCategory(id: MoneyUsageCategoryId): Boolean {
+        return runCatching {
+            apolloClient
+                .mutation(
+                    DeleteCategoryMutation(
                         id = id,
                     ),
                 )

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingScreenCategoryApi.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingScreenCategoryApi.kt
@@ -171,6 +171,6 @@ public class SettingScreenCategoryApi(
                     ),
                 )
                 .execute()
-        }.getOrNull()?.data?.userMutation != null
+        }.getOrNull()?.data?.userMutation?.deleteCategory == true
     }
 }

--- a/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/viewmodel/NotificationUsageDetailViewModel.kt
+++ b/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/viewmodel/NotificationUsageDetailViewModel.kt
@@ -109,7 +109,7 @@ public class NotificationUsageDetailViewModel(
                 .query(
                     NotificationUsageCategoryFiltersQuery(
                         query = ImportedMailCategoryFiltersQuery(
-                            size = 1000,
+                            size = Optional.present(1000),
                             isAsc = true,
                             sortType = Optional.present(ImportedMailCategoryFiltersSortType.ORDER_NUMBER),
                         ),


### PR DESCRIPTION
カテゴリにはadd/get/updateのみ存在し、deleteが未実装だった。`deleteSubCategory`のパターンに倣い、カテゴリ削除機能をバックエンド・フロントエンド全層で実装する。

## Backend

- `user_mutation.graphqls`: `deleteCategory(id: MoneyUsageCategoryId!): Boolean!` を追加
- `MoneyUsageCategoryRepository`: `deleteCategory` メソッドをインターフェースに追加
- `DbMoneyUsageCategoryRepository`: カスケード削除を実装（`money_usage_sub_categories` → `money_usage_categories` の順で削除）
- `UserMutationResolverImpl`: `deleteSubCategory` と同パターンで `deleteCategory` リゾルバーを追加

## Frontend

- `user_mutation.graphql`: `DeleteCategory` ミューテーションを追加
- `SettingScreenCategoryApi`: `deleteCategory(id)` メソッドを追加
- `SettingCategoryScreenUiState`: `ConfirmDialog` データクラスと `confirmDialog` フィールドを追加、`Event` に `onClickDeleteCategory()` を追加
- `CategorySettingScreen`: ヘッダーに削除ボタンを追加、確認ダイアログ（AlertDialog）を表示
- `SettingCategoryViewModel`: 削除前に`responseList`からサブカテゴリ件数を算出し、あれば `"n件のサブカテゴリーが紐づいています"` を `description` として確認ダイアログに渡す。削除成功後はスナックバー表示 + `navigateToCategories()` でカテゴリ一覧へ遷移
- `ViewModelEventHandlers.handleSettingCategory`: `navigateToCategories()` で `ScreenStructure.Root.Settings.Categories` へ遷移するよう実装

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `dl.google.com`
>   - Triggering command: `/usr/lib/jvm/temurin-17-jdk-amd64/bin/java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.xml/javax.xml.namespace=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED -XX:&#43;HeapDumpOnOutOfMemoryError -XX:&#43;UseParallelGC -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/matsudamper/kake-bo/settings/copilot/coding_agent) (admins only)
>
> </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 利用カテゴリーの削除機能を追加しました。カテゴリー設定画面から削除ボタンをクリックすると、確認ダイアログが表示され、削除前に内容を確認できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->