### PR TITLE
HTMLをエスケープする

### DIFF
--- a/frontend/common/base/src/commonMain/kotlin/net/matsudamper/money/frontend/common/base/HtmlEscape.kt
+++ b/frontend/common/base/src/commonMain/kotlin/net/matsudamper/money/frontend/common/base/HtmlEscape.kt
@@ -1,0 +1,12 @@
+package net.matsudamper.money.frontend.common.base
+
+public object HtmlEscape {
+    public fun escape(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#39;")
+    }
+}

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/importedmail/plain/ImportedMailPlainViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/importedmail/plain/ImportedMailPlainViewModel.kt
@@ -11,8 +11,8 @@ import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import net.matsudamper.money.element.ImportedMailId
-import net.matsudamper.money.frontend.common.base.IO
 import net.matsudamper.money.frontend.common.base.HtmlEscape
+import net.matsudamper.money.frontend.common.base.IO
 import net.matsudamper.money.frontend.common.base.nav.ScopedObjectFeature
 import net.matsudamper.money.frontend.common.ui.screen.importedmail.plain.ImportedMailPlainScreenUiState
 import net.matsudamper.money.frontend.common.viewmodel.CommonViewModel

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/importedmail/plain/ImportedMailPlainViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/importedmail/plain/ImportedMailPlainViewModel.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import net.matsudamper.money.element.ImportedMailId
 import net.matsudamper.money.frontend.common.base.IO
+import net.matsudamper.money.frontend.common.base.HtmlEscape
 import net.matsudamper.money.frontend.common.base.nav.ScopedObjectFeature
 import net.matsudamper.money.frontend.common.ui.screen.importedmail.plain.ImportedMailPlainScreenUiState
 import net.matsudamper.money.frontend.common.viewmodel.CommonViewModel
@@ -78,14 +79,15 @@ public class ImportedMailPlainViewModel(
                     return@collectLatest
                 }
 
+                val plain = mailData.plain
                 loadingState = ImportedMailPlainScreenUiState.LoadingState.Loaded(
-                    html = sequence {
-                        yield(
-                            mailData.plain
-                                ?.replace("\r\n", "<br>")
-                                ?.replace("\n", "<br>"),
-                        )
-                    }.filterNotNull().firstOrNull().orEmpty(),
+                    html = if (plain != null) {
+                        HtmlEscape.escape(plain)
+                            .replace("\r\n", "<br>")
+                            .replace("\n", "<br>")
+                    } else {
+                        ""
+                    },
                 )
 
                 uiStateFlow.update {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * インポートされたメールのプレーンテキスト表示において、HTML特殊文字の処理を改善しました。
  * メール本文の改行表示を正確に処理するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->