### PR TITLE
管理画面のレイアウトを整理

### DIFF
--- a/frontend/common/navigation/src/commonMain/kotlin/net/matsudamper/money/frontend/common/base/nav/admin/AdminScreenController.kt
+++ b/frontend/common/navigation/src/commonMain/kotlin/net/matsudamper/money/frontend/common/base/nav/admin/AdminScreenController.kt
@@ -2,6 +2,7 @@ package net.matsudamper.money.frontend.common.base.nav.admin
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,7 +25,7 @@ public fun rememberAdminScreenController(): AdminScreenController {
     }
 }
 
-public enum class AdminScreenType {
+public enum class AdminScreenType : NavKey {
     Login,
     Root,
     AddUser,

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AddUserScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AddUserScreen.kt
@@ -5,11 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,26 +19,29 @@ import androidx.compose.ui.unit.dp
 import net.matsudamper.money.frontend.common.ui.layout.html.text.input.HtmlTextInput
 import net.matsudamper.money.frontend.common.ui.rememberCustomFontFamily
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun AddUserScreen(
     modifier: Modifier = Modifier,
     uiState: AdminAddUserUiState,
 ) {
-    Scaffold(
-        modifier = modifier,
-        topBar = {
-            Text(
-                text = "ユーザー追加",
-                fontFamily = rememberCustomFontFamily(),
-            )
-        },
-        contentColor = MaterialTheme.colorScheme.onSurface,
+    Card(
+        modifier = modifier
+            .padding(24.dp)
+            .widthIn(max = 480.dp)
+            .fillMaxWidth(),
     ) {
         Column(
+            modifier = Modifier
+                .padding(24.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Text(
+                text = "ユーザー追加",
+                style = MaterialTheme.typography.titleLarge,
+                fontFamily = rememberCustomFontFamily(),
+            )
+            Spacer(modifier = Modifier.height(20.dp))
             HtmlTextInput(
                 modifier = Modifier.fillMaxWidth()
                     .height(48.dp),
@@ -58,7 +62,7 @@ internal fun AddUserScreen(
                 fontFamily = rememberCustomFontFamily(),
             )
             Spacer(modifier = Modifier.height(12.dp))
-            Button(
+            TextButton(
                 modifier = Modifier.align(Alignment.End),
                 onClick = { uiState.onClickAddButton() },
             ) {

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AddUserScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AddUserScreen.kt
@@ -14,9 +14,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import net.matsudamper.money.frontend.common.ui.layout.html.text.input.HtmlTextInput
+import net.matsudamper.money.frontend.common.ui.layout.TextField
+import net.matsudamper.money.frontend.common.ui.layout.TextFieldType
 import net.matsudamper.money.frontend.common.ui.rememberCustomFontFamily
 
 @Composable
@@ -42,20 +43,31 @@ internal fun AddUserScreen(
                 fontFamily = rememberCustomFontFamily(),
             )
             Spacer(modifier = Modifier.height(20.dp))
-            HtmlTextInput(
-                modifier = Modifier.fillMaxWidth()
-                    .height(48.dp),
-                placeholder = "ユーザー名",
-                onValueChange = { uiState.onChangeUserName(it.text) },
-                type = KeyboardType.Text,
+            val textFieldTextStyle = MaterialTheme.typography.bodyMedium
+                .merge(
+                    TextStyle(
+                        fontFamily = rememberCustomFontFamily(),
+                    ),
+                )
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                text = uiState.userName.text,
+                textStyle = textFieldTextStyle,
+                label = "User Name",
+                maxLines = 1,
+                onValueChange = { uiState.onChangeUserName(it) },
+                autocomplete = "username",
             )
             Spacer(modifier = Modifier.height(12.dp))
-            HtmlTextInput(
-                modifier = Modifier.fillMaxWidth()
-                    .height(48.dp),
-                placeholder = "パスワード",
-                onValueChange = { uiState.onChangePassword(it.text) },
-                type = KeyboardType.Password,
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                text = uiState.password.text,
+                textStyle = textFieldTextStyle,
+                label = "Password",
+                maxLines = 1,
+                onValueChange = { uiState.onChangePassword(it) },
+                type = TextFieldType.Password,
+                autocomplete = "new-password",
             )
             Text(
                 "使用できる記号 !@#\$%^&*()_+-?<>,.",

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AdminRootScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AdminRootScreen.kt
@@ -10,6 +10,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.DialogProperties
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.scene.DialogSceneStrategy
+import androidx.navigation3.ui.NavDisplay
 import net.matsudamper.money.frontend.common.base.nav.admin.AdminScreenController
 import net.matsudamper.money.frontend.common.base.nav.admin.AdminScreenControllerImpl
 import net.matsudamper.money.frontend.common.base.nav.admin.AdminScreenType
@@ -31,35 +35,62 @@ public fun AdminRootScreen(
             .fillMaxSize()
             .padding(windowInsets),
     ) {
-        when (screenStack.lastOrNull()) {
-            null -> {
-                CircularProgressIndicator(
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
+        if (screenStack.isEmpty()) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center),
+            )
+        } else {
+            NavDisplay(
+                backStack = screenStack,
+                modifier = Modifier.fillMaxSize(),
+                sceneStrategy = DialogSceneStrategy(),
+                onBack = {
+                    adminScreenController.popBackStack()
+                },
+                entryProvider = { screen ->
+                    when (screen) {
+                        AdminScreenType.Login -> {
+                            NavEntry(
+                                key = screen,
+                            ) {
+                                val uiState = adminLoginScreenUiStateProvider()
+                                AdminLoginScreen(
+                                    uiState = uiState,
+                                )
+                            }
+                        }
 
-            AdminScreenType.Login -> {
-                val uiState = adminLoginScreenUiStateProvider()
-                AdminLoginScreen(
-                    uiState = uiState,
-                )
-            }
+                        AdminScreenType.Root -> {
+                            NavEntry(
+                                key = screen,
+                            ) {
+                                saveableStateHolder.SaveableStateProvider(AdminScreenType.Root.name) {
+                                    val uiState = adminRootScreenUiStateProvider()
+                                    AdminRootScreen(
+                                        uiState = uiState,
+                                    )
+                                }
+                            }
+                        }
 
-            AdminScreenType.Root -> {
-                saveableStateHolder.SaveableStateProvider(AdminScreenType.Root.name) {
-                    val uiState = adminRootScreenUiStateProvider()
-                    AdminRootScreen(
-                        uiState = uiState,
-                    )
-                }
-            }
-
-            AdminScreenType.AddUser -> {
-                val uiState = adminAddUserUiStateProvider()
-                AddUserScreen(
-                    uiState = uiState,
-                )
-            }
+                        AdminScreenType.AddUser -> {
+                            NavEntry(
+                                key = screen,
+                                metadata = DialogSceneStrategy.dialog(
+                                    dialogProperties = DialogProperties(
+                                        usePlatformDefaultWidth = false,
+                                    ),
+                                ),
+                            ) {
+                                val uiState = adminAddUserUiStateProvider()
+                                AddUserScreen(
+                                    uiState = uiState,
+                                )
+                            }
+                        }
+                    }
+                },
+            )
         }
     }
 }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AdminRootScreenUiState.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AdminRootScreenUiState.kt
@@ -26,6 +26,8 @@ public data class AdminRootScreenUiState(
 }
 
 public data class AdminAddUserUiState(
+    val userName: TextFieldValue,
+    val password: TextFieldValue,
     val onChangeUserName: (String) -> Unit,
     val onChangePassword: (String) -> Unit,
     val onClickAddButton: () -> Unit,

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AdminScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/admin/AdminScreen.kt
@@ -1,17 +1,33 @@
 package net.matsudamper.money.frontend.common.ui.screen.admin
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import net.matsudamper.money.frontend.common.ui.rememberCustomFontFamily
 
@@ -44,36 +60,73 @@ internal fun AdminRootScreen(
             )
         },
     ) { innerPadding ->
-        Column(
-            modifier = Modifier.padding(innerPadding),
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
         ) {
-            RootSettingItem(
-                text = {
-                    Text(
-                        text = "ユーザー追加",
-                        fontFamily = rememberCustomFontFamily(),
+            val horizontalPadding = ((maxWidth - 600.dp) / 2).coerceAtLeast(0.dp)
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                contentPadding = PaddingValues(
+                    horizontal = horizontalPadding,
+                    vertical = 8.dp,
+                ),
+            ) {
+                item {
+                    RootTileItem(
+                        modifier = Modifier.padding(8.dp),
+                        title = {
+                            Text(
+                                text = "ユーザー追加",
+                                fontFamily = rememberCustomFontFamily(),
+                            )
+                        },
+                        icon = {
+                            Row {
+                                Icon(Icons.Default.Add, contentDescription = null)
+                                Icon(Icons.Default.Settings, contentDescription = null)
+                            }
+                        },
+                        onClick = { uiState.listener.onClickAddUser() },
                     )
-                },
-                onClick = { uiState.listener.onClickAddUser() },
-            )
-            HorizontalDivider(modifier = Modifier.fillMaxWidth())
+                }
+            }
         }
     }
 }
 
 @Composable
-private fun RootSettingItem(
+private fun RootTileItem(
     modifier: Modifier = Modifier,
-    text: @Composable () -> Unit,
+    title: @Composable () -> Unit,
+    icon: @Composable () -> Unit,
     onClick: () -> Unit,
 ) {
-    Column(
-        modifier = modifier.fillMaxWidth()
-            .clickable {
-                onClick()
-            }
-            .padding(12.dp),
+    Card(
+        modifier = modifier
+            .heightIn(min = 140.dp)
+            .height(IntrinsicSize.Max)
+            .fillMaxSize(),
+        onClick = onClick,
     ) {
-        text()
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                icon()
+            }
+            Spacer(modifier = Modifier.weight(1f).fillMaxWidth())
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.BottomStart,
+            ) {
+                title()
+            }
+        }
     }
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/admin/AdminAddUserScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/admin/AdminAddUserScreenViewModel.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.money.frontend.common.viewmodel.admin
 
+import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,21 +21,23 @@ public class AdminAddUserScreenViewModel(
 
     public val uiStateFlow: StateFlow<AdminAddUserUiState> = MutableStateFlow(
         AdminAddUserUiState(
+            userName = TextFieldValue(),
+            password = TextFieldValue(),
             onChangeUserName = {
                 viewModelStateFlow.update { viewModelState ->
-                    viewModelState.copy(userName = it)
+                    viewModelState.copy(userName = TextFieldValue(it))
                 }
             },
             onChangePassword = {
                 viewModelStateFlow.update { viewModelState ->
-                    viewModelState.copy(password = it)
+                    viewModelState.copy(password = TextFieldValue(it))
                 }
             },
             onClickAddButton = {
                 viewModelScope.launch {
                     val result = adminQuery.addUser(
-                        userName = viewModelStateFlow.value.userName,
-                        password = viewModelStateFlow.value.password,
+                        userName = viewModelStateFlow.value.userName.text,
+                        password = viewModelStateFlow.value.password.text,
                     )
                     println("data: ${result.data}")
                     println("errors: ${result.data?.adminMutation?.addUser?.errorType.orEmpty().joinToString(",")}")
@@ -43,10 +46,20 @@ public class AdminAddUserScreenViewModel(
             },
         ),
     ).also { uiStateFlow ->
+        viewModelScope.launch {
+            viewModelStateFlow.collect { viewModelState ->
+                uiStateFlow.update { uiState ->
+                    uiState.copy(
+                        userName = viewModelState.userName,
+                        password = viewModelState.password,
+                    )
+                }
+            }
+        }
     }.asStateFlow()
 
     private data class ViewModelState(
-        val userName: String = "",
-        val password: String = "",
+        val userName: TextFieldValue = TextFieldValue(),
+        val password: TextFieldValue = TextFieldValue(),
     )
 }


### PR DESCRIPTION
<img width="2145" height="529" alt="image" src="https://github.com/user-attachments/assets/f08921bc-905a-4dfa-af0f-f6a11a37fcc3" />
<img width="2155" height="1238" alt="image" src="https://github.com/user-attachments/assets/57ce3ff2-8c80-409c-a075-6909af089e83" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 管理画面のユーザーインターフェイスをリデザイン
  * ユーザー入力フィールドにラベルと自動補完機能を追加
  * 管理メニューをレスポンシブグリッドタイルレイアウトで表示
  * ナビゲーションフローを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->