### PR TITLE
ci: healthz smoke testのログを強化してランダム失敗の診断を容易にする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,14 +55,23 @@ jobs:
           tar -xf backend/build/distributions/backend.tar -C backend-server --strip-components=1
           export $(grep -v '^#' schema_update_local.env | xargs)
           export PORT=8080
-          ./backend-server/bin/backend &
+
+          SERVER_LOG=backend-server/server.log
+          ./backend-server/bin/backend > "$SERVER_LOG" 2>&1 &
           SERVER_PID=$!
+          echo "サーバーを起動しました (PID: ${SERVER_PID}, PORT: ${PORT})"
 
           TIMEOUT=60
           ELAPSED=0
           until curl -sf --max-time 5 http://localhost:${PORT}/healthz > /dev/null 2>&1; do
             if [ $ELAPSED -ge $TIMEOUT ]; then
               echo "サーバー起動がタイムアウトしました (${TIMEOUT}秒)"
+              echo "--- サーバーログ ---"
+              cat "$SERVER_LOG" || true
+              echo "--- プロセス状態 ---"
+              ps -p "$SERVER_PID" 2>/dev/null || echo "プロセスはすでに終了しています"
+              echo "--- ポート使用状況 ---"
+              ss -tlnp | grep ":${PORT}" || echo "ポート ${PORT} は使用されていません"
               kill $SERVER_PID 2>/dev/null || true
               exit 1
             fi
@@ -72,9 +81,11 @@ jobs:
 
           RESPONSE=$(curl -sf --max-time 5 http://localhost:${PORT}/healthz)
           if [ "$RESPONSE" = "ok" ]; then
-            echo "healthzチェック成功"
+            echo "healthzチェック成功 (${ELAPSED}秒で起動)"
           else
             echo "healthzチェック失敗: $RESPONSE"
+            echo "--- サーバーログ ---"
+            cat "$SERVER_LOG" || true
             kill $SERVER_PID 2>/dev/null || true
             exit 1
           fi


### PR DESCRIPTION
## 概要\n\nmainへのpushでランダムに失敗する可能性があるテストの調査の一環として、`Backend healthz smoke test` ステップのログを強化します。\n\n現状、タイムアウトや失敗時に原因を特定するための情報が不足しており、何が起きているか分かりません。\n\n## 変更内容\n\n**失敗時・タイムアウト時に以下を出力するよう改善:**\n- サーバーの stdout/stderr ログ (`server.log` へキャプチャして表示)\n- プロセス状態 (`ps` でサーバーPIDが生存しているか確認)\n- ポート使用状況 (`ss -tlnp` でポートが bind されているか確認)\n\n**その他:**\n- 起動時にPIDとポート番号をログ出力\n- healthz成功時に起動にかかった秒数を表示\n- healthz失敗時もサーバーログを表示\n\n## 目的\n\n今後ランダム失敗が発生した際に、次のどれが原因かを特定できるようにする:\n- サーバーが起動途中にクラッシュしている\n- サーバーが起動しているがポートをbindできていない\n- サーバーがポートをbindしているがhealthzが正常でない\n- 60秒のタイムアウトが不足している

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYVCEturj7yfCw3Y5yaDL9)_