### PR TITLE
バックボタンでeditModeを解除する

### DIFF
--- a/frontend/common/ui/src/androidMain/kotlin/net/matsudamper/money/frontend/common/ui/base/ScreenBackHandler.android.kt
+++ b/frontend/common/ui/src/androidMain/kotlin/net/matsudamper/money/frontend/common/ui/base/ScreenBackHandler.android.kt
@@ -1,0 +1,15 @@
+package net.matsudamper.money.frontend.common.ui.base
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+
+@Composable
+public actual fun ScreenBackHandler(
+    enabled: Boolean,
+    onBack: () -> Unit,
+) {
+    BackHandler(
+        enabled = enabled,
+        onBack = onBack,
+    )
+}

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/base/ScreenBackHandler.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/base/ScreenBackHandler.kt
@@ -1,0 +1,9 @@
+package net.matsudamper.money.frontend.common.ui.base
+
+import androidx.compose.runtime.Composable
+
+@Composable
+public expect fun ScreenBackHandler(
+    enabled: Boolean,
+    onBack: () -> Unit,
+)

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
@@ -66,6 +66,7 @@ import net.matsudamper.money.frontend.common.base.ColorUtil
 import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.ui.AppRoot
 import net.matsudamper.money.frontend.common.ui.base.KakeboScaffoldListener
+import net.matsudamper.money.frontend.common.ui.base.ScreenBackHandler
 import net.matsudamper.money.frontend.common.ui.layout.AlertDialog
 import net.matsudamper.money.frontend.common.ui.layout.colorpicker.ColorPickerDialog
 
@@ -159,6 +160,15 @@ public fun SettingCategoryScreen(
     LaunchedEffect(Unit) {
         uiState.event.onResume()
     }
+    val isSubCategoryEditing = (uiState.loadingState as? SettingCategoryScreenUiState.LoadingState.Loaded)
+        ?.item
+        ?.any { it.isEditing } == true
+    val shouldHandleBackAsEditCancel =
+        uiState.heroMode == SettingCategoryScreenUiState.HeroMode.EditingCategoryName || isSubCategoryEditing
+
+    ScreenBackHandler(enabled = shouldHandleBackAsEditCancel) {
+        uiState.event.onClickBack()
+    }
 
     if (uiState.showColorPickerDialog) {
         ColorPickerDialog(
@@ -223,6 +233,9 @@ private fun LoadedContent(
     windowInsets: PaddingValues,
 ) {
     val heroColor = uiState.categoryColor ?: MaterialTheme.colorScheme.primary
+    val shouldHandleBackAsEditCancel =
+        uiState.heroMode == SettingCategoryScreenUiState.HeroMode.EditingCategoryName ||
+            loadedState.item.any { it.isEditing }
 
     Box(modifier = modifier) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -231,11 +244,11 @@ private fun LoadedContent(
                 categoryName = uiState.categoryName,
                 categoryColor = heroColor,
                 heroMode = uiState.heroMode,
+                shouldHandleBackAsEditCancel = shouldHandleBackAsEditCancel,
                 windowInsets = windowInsets,
                 onClickBack = { uiState.event.onClickBack() },
                 onClickEditCategoryName = { uiState.event.onClickEditCategoryName() },
                 onCategoryNameEditComplete = { text -> uiState.event.onCategoryNameEditComplete(text) },
-                onCategoryNameEditDismiss = { uiState.event.onCategoryNameEditDismiss() },
                 onClickChangeColor = { uiState.event.onClickChangeColor() },
                 onClickDeleteCategory = { uiState.event.onClickDeleteCategory() },
             )
@@ -313,17 +326,17 @@ private fun HeroSection(
     categoryName: String,
     categoryColor: Color,
     heroMode: SettingCategoryScreenUiState.HeroMode,
+    shouldHandleBackAsEditCancel: Boolean,
     windowInsets: PaddingValues,
     onClickBack: () -> Unit,
     onClickEditCategoryName: () -> Unit,
     onCategoryNameEditComplete: (String) -> Unit,
-    onCategoryNameEditDismiss: () -> Unit,
     onClickChangeColor: () -> Unit,
     onClickDeleteCategory: () -> Unit,
 ) {
-    val isEditMode = heroMode == SettingCategoryScreenUiState.HeroMode.EditingCategoryName
+    val isCategoryNameEditMode = heroMode == SettingCategoryScreenUiState.HeroMode.EditingCategoryName
     val topPadding = windowInsets.calculateTopPadding()
-    var editingText by rememberSaveable(categoryName, isEditMode) { mutableStateOf(categoryName) }
+    var editingText by rememberSaveable(categoryName, isCategoryNameEditMode) { mutableStateOf(categoryName) }
 
     Box(
         modifier = modifier
@@ -338,11 +351,11 @@ private fun HeroSection(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 4.dp, end = 8.dp),
-                isEditMode = isEditMode,
+                isCategoryNameEditMode = isCategoryNameEditMode,
+                shouldHandleBackAsEditCancel = shouldHandleBackAsEditCancel,
                 editingText = editingText,
                 onClickBack = onClickBack,
                 onCategoryNameEditComplete = onCategoryNameEditComplete,
-                onCategoryNameEditDismiss = onCategoryNameEditDismiss,
                 onClickDeleteCategory = onClickDeleteCategory,
             )
 
@@ -352,7 +365,7 @@ private fun HeroSection(
                     .padding(start = 20.dp, end = 20.dp, top = 4.dp, bottom = 24.dp),
                 categoryName = categoryName,
                 categoryColor = categoryColor,
-                isEditMode = isEditMode,
+                isEditMode = isCategoryNameEditMode,
                 editingText = editingText,
                 onEditingTextChange = { editingText = it },
                 onClickEditCategoryName = onClickEditCategoryName,
@@ -365,11 +378,11 @@ private fun HeroSection(
 @Composable
 private fun HeroTopBar(
     modifier: Modifier,
-    isEditMode: Boolean,
+    isCategoryNameEditMode: Boolean,
+    shouldHandleBackAsEditCancel: Boolean,
     editingText: String,
     onClickBack: () -> Unit,
     onCategoryNameEditComplete: (String) -> Unit,
-    onCategoryNameEditDismiss: () -> Unit,
     onClickDeleteCategory: () -> Unit,
 ) {
     var showMoreMenu by remember { mutableStateOf(false) }
@@ -379,17 +392,11 @@ private fun HeroTopBar(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(
-            onClick = {
-                if (isEditMode) {
-                    onCategoryNameEditDismiss()
-                } else {
-                    onClickBack()
-                }
-            },
+            onClick = onClickBack,
         ) {
             Icon(
-                imageVector = if (isEditMode) Icons.Default.Close else Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = if (isEditMode) "キャンセル" else "戻る",
+                imageVector = if (shouldHandleBackAsEditCancel) Icons.Default.Close else Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = if (shouldHandleBackAsEditCancel) "キャンセル" else "戻る",
                 tint = Color.White,
             )
         }
@@ -401,7 +408,7 @@ private fun HeroTopBar(
             color = Color.White,
         )
 
-        if (isEditMode) {
+        if (isCategoryNameEditMode) {
             TextButton(onClick = { onCategoryNameEditComplete(editingText) }) {
                 Text(
                     text = "完了",

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Card
@@ -224,7 +223,6 @@ private fun LoadedContent(
     windowInsets: PaddingValues,
 ) {
     val heroColor = uiState.categoryColor ?: MaterialTheme.colorScheme.primary
-    val isEditMode = uiState.heroMode == SettingCategoryScreenUiState.HeroMode.EditingCategoryName
 
     Box(modifier = modifier) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -248,24 +246,14 @@ private fun LoadedContent(
                     .weight(1f)
                     .fillMaxWidth(),
                 state = lazyListState,
-                contentPadding = PaddingValues(bottom = if (isEditMode) 24.dp else 88.dp),
+                contentPadding = PaddingValues(bottom = 88.dp),
             ) {
-                if (isEditMode) {
-                    item {
-                        Text(
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
-                            text = "ドラッグして並び替え",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
                 item {
                     SubCategoryHeader(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp)
-                            .padding(top = if (isEditMode) 0.dp else 16.dp, bottom = 8.dp),
+                            .padding(top = 16.dp, bottom = 8.dp),
                         count = loadedState.item.size,
                     )
                 }
@@ -294,50 +282,14 @@ private fun LoadedContent(
                             .padding(horizontal = 12.dp),
                         item = item,
                         position = position,
-                        isEditMode = isEditMode,
                         isAddMode = uiState.isAddingSubCategory,
                     )
-                }
-                if (isEditMode) {
-                    item {
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 8.dp),
-                            shape = RoundedCornerShape(12.dp),
-                            colors = CardDefaults.cardColors(
-                                containerColor = MaterialTheme.colorScheme.surface,
-                            ),
-                            elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
-                            onClick = { uiState.event.onClickAddSubCategory() },
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 14.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(20.dp),
-                                )
-                                Spacer(Modifier.width(10.dp))
-                                Text(
-                                    text = "サブカテゴリを追加",
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        }
-                    }
                 }
                 item { Spacer(Modifier.height(8.dp)) }
             }
         }
 
-        if (!isEditMode && !uiState.isAddingSubCategory) {
+        if (!uiState.isAddingSubCategory) {
             ExtendedFloatingActionButton(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
@@ -728,13 +680,11 @@ private enum class RowPosition { Single, First, Middle, Last }
 @Composable
 private fun SubCategoryRow(
     item: SettingCategoryScreenUiState.SubCategoryItem,
-    isEditMode: Boolean,
     isAddMode: Boolean,
     position: RowPosition,
     modifier: Modifier = Modifier,
 ) {
     val accentColor = MaterialTheme.colorScheme.primary
-    val errorColor = MaterialTheme.colorScheme.error
     val rowShape = when (position) {
         RowPosition.Single -> RoundedCornerShape(12.dp)
         RowPosition.First -> RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
@@ -823,16 +773,6 @@ private fun SubCategoryRow(
                     .padding(start = 16.dp, top = 4.dp, bottom = 4.dp, end = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (isEditMode) {
-                    Icon(
-                        imageVector = Icons.Default.DragIndicator,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier
-                            .size(22.dp)
-                            .padding(end = 4.dp),
-                    )
-                }
                 Text(
                     modifier = Modifier
                         .weight(1f)
@@ -845,7 +785,7 @@ private fun SubCategoryRow(
                         MaterialTheme.colorScheme.onSurface
                     },
                 )
-                if (!isEditMode && !isAddMode) {
+                if (!isAddMode) {
                     IconButton(onClick = { item.event.onClickEdit() }) {
                         Icon(
                             imageVector = Icons.Default.Edit,
@@ -861,14 +801,14 @@ private fun SubCategoryRow(
                             imageVector = Icons.Default.Close,
                             contentDescription = "削除",
                             modifier = Modifier.size(18.dp),
-                            tint = if (isEditMode) errorColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
             }
             if (!isLast) {
                 HorizontalDivider(
-                    modifier = Modifier.padding(start = if (isEditMode) 40.dp else 16.dp),
+                    modifier = Modifier.padding(start = 16.dp),
                     color = MaterialTheme.colorScheme.outlineVariant,
                 )
             }

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/base/ScreenBackHandler.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/base/ScreenBackHandler.js.kt
@@ -1,0 +1,10 @@
+package net.matsudamper.money.frontend.common.ui.base
+
+import androidx.compose.runtime.Composable
+
+@Composable
+public actual fun ScreenBackHandler(
+    enabled: Boolean,
+    onBack: () -> Unit,
+) {
+}

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/settings/SettingCategoryViewModel.kt
@@ -50,6 +50,10 @@ public class SettingCategoryViewModel(
                 }
 
                 override fun onClickBack() {
+                    if (clearEditModeIfNeeded()) {
+                        return
+                    }
+
                     viewModelScope.launch {
                         viewModelEventSender.send {
                             it.navigateToCategories()
@@ -446,6 +450,21 @@ public class SettingCategoryViewModel(
                     }
                 }
         }
+    }
+
+    private fun clearEditModeIfNeeded(): Boolean {
+        val viewModelState = viewModelStateFlow.value
+        if (!viewModelState.isEditingCategoryName && viewModelState.editingSubCategoryId == null) {
+            return false
+        }
+
+        viewModelStateFlow.update {
+            it.copy(
+                isEditingCategoryName = false,
+                editingSubCategoryId = null,
+            )
+        }
+        return true
     }
 
     private data class ViewModelState(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カテゴリ設定画面でのバックナビゲーション動作を改善しました。編集モード中のバックボタンはキャンセルボタンとして機能するようになりました。

* **改善**
  * カテゴリ設定画面のUIを簡潔にしました。編集時の不要な補助表示と操作要素を削除し、より使いやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->