### PR TITLE
ci: native healthzスモークテストに失敗時診断ログを追加

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -47,14 +47,22 @@ jobs:
           mkdir -p /tmp/html
           echo '<html></html>' > /tmp/html/index.html
 
-          ./backend/build/native/nativeCompile/backend &
+          SERVER_LOG=backend-native-server.log
+          ./backend/build/native/nativeCompile/backend > "$SERVER_LOG" 2>&1 &
           SERVER_PID=$!
+          echo "サーバーを起動しました (PID: ${SERVER_PID}, PORT: ${PORT})"
 
           TIMEOUT=60
           ELAPSED=0
           until curl -sf --max-time 5 http://localhost:${PORT}/healthz > /dev/null 2>&1; do
             if [ $ELAPSED -ge $TIMEOUT ]; then
               echo "サーバー起動がタイムアウトしました (${TIMEOUT}秒)"
+              echo "--- サーバーログ ---"
+              cat "$SERVER_LOG" || true
+              echo "--- プロセス状態 ---"
+              ps -p "$SERVER_PID" 2>/dev/null || echo "プロセスはすでに終了しています"
+              echo "--- ポート使用状況 ---"
+              ss -tlnp | grep ":${PORT}" || echo "ポート ${PORT} は使用されていません"
               kill $SERVER_PID 2>/dev/null || true
               exit 1
             fi
@@ -64,9 +72,11 @@ jobs:
 
           RESPONSE=$(curl -sf --max-time 5 http://localhost:${PORT}/healthz)
           if [ "$RESPONSE" = "ok" ]; then
-            echo "healthzチェック成功"
+            echo "healthzチェック成功 (${ELAPSED}秒で起動)"
           else
             echo "healthzチェック失敗: $RESPONSE"
+            echo "--- サーバーログ ---"
+            cat "$SERVER_LOG" || true
             kill $SERVER_PID 2>/dev/null || true
             exit 1
           fi


### PR DESCRIPTION
## 概要\n\nmainへのpushでランダムに失敗する可能性があるテストの調査の一環として、`native-build.yml` の「ネイティブバイナリの healthz スモークテスト」ステップのログを強化します。\n\n`build.yml` の JVM 版 healthz テストは PR #748 で診断ログが追加されましたが、`native-build.yml` の同等ステップは未対応のままでした。\n\n## 変更内容\n\n**失敗時・タイムアウト時に以下を出力するよう改善:**\n- サーバーの stdout/stderr ログ (`backend-native-server.log` へキャプチャして表示)\n- プロセス状態 (`ps` でサーバーPIDが生存しているか確認)\n- ポート使用状況 (`ss -tlnp` でポートが bind されているか確認)\n\n**その他:**\n- 起動時にPIDとポート番号をログ出力\n- healthz成功時に起動にかかった秒数を表示\n- healthz失敗時もサーバーログを表示\n\n## 目的\n\n今後ネイティブビルドのhealthzがランダム失敗した際に、次のどれが原因かを特定できるようにする:\n- ネイティブバイナリが起動途中にクラッシュしている\n- バイナリが起動しているがポートをbindできていない\n- ポートをbindしているがhealthzが正常でない\n- 60秒のタイムアウトが不足している

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkread8Sadf59XoVpUNoQh)_