### PR TITLE
Add Samsung Pay notification usage parser

### DIFF
--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/NotificationUsageModule.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/NotificationUsageModule.kt
@@ -31,6 +31,7 @@ public object NotificationUsageModule {
         single<NotificationUsageParser>(named("com.felicanetworks.mfm.main")) { MobileSuicaNotificationUsageParser() }
         single<NotificationUsageParser>(named("jp.co.saisoncard.android.saisonportal")) { SaisonCardNotificationUsageParser() }
         single<NotificationUsageParser>(named("com.google.android.apps.walletnfcrel")) { GoogleWalletNotificationUsageParser() }
+        single<NotificationUsageParser>(named("com.samsung.android.spay")) { SamsungPayNotificationUsageParser() }
         single<NotificationUsageAutoAddApi> {
             NotificationUsageAutoAddGraphqlApi(
                 graphqlClient = get<GraphqlClient>(),

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SamsungPayNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SamsungPayNotificationUsageParser.kt
@@ -25,7 +25,7 @@ internal class SamsungPayNotificationUsageParser : NotificationUsageParser {
 
         return NotificationUsageDraft(
             title = title,
-            description = record.text,
+            description = "${record.text}\nvia Samsung Pay",
             amount = amount,
             dateTime = Instant.fromEpochMilliseconds(record.postedAtEpochMillis)
                 .toLocalDateTime(TimeZone.currentSystemDefault()),

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SamsungPayNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SamsungPayNotificationUsageParser.kt
@@ -1,0 +1,43 @@
+package net.matsudamper.money.frontend.android.feature.notificationusage
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageDraft
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageFilterDefinition
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageParser
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageRecord
+
+internal class SamsungPayNotificationUsageParser : NotificationUsageParser {
+    override val filterDefinition: NotificationUsageFilterDefinition = NotificationUsageFilterDefinition(
+        id = "com.samsung.android.spay",
+        title = "Samsung Pay",
+        description = "Samsung Payの利用通知を解析します。利用金額・利用店舗を抽出します。",
+    )
+
+    override fun parse(record: NotificationUsageRecord): NotificationUsageDraft? {
+        if (record.packageName != "com.samsung.android.spay") return null
+
+        val lines = record.text.lines()
+        val secondLine = lines.getOrNull(1) ?: return null
+        val amount = parseAmount(secondLine) ?: return null
+        val title = parseTitle(secondLine)
+
+        return NotificationUsageDraft(
+            title = title,
+            description = record.text,
+            amount = amount,
+            dateTime = Instant.fromEpochMilliseconds(record.postedAtEpochMillis)
+                .toLocalDateTime(TimeZone.currentSystemDefault()),
+        )
+    }
+
+    private fun parseAmount(text: String): Int? {
+        val match = Regex("""￥([0-9,]+)""").find(text) ?: return null
+        return match.groupValues[1].replace(",", "").toIntOrNull()
+    }
+
+    private fun parseTitle(text: String): String {
+        return text.replace(Regex("""￥[0-9,]+"""), "").trim()
+    }
+}

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SamsungPayNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SamsungPayNotificationUsageParser.kt
@@ -21,7 +21,7 @@ internal class SamsungPayNotificationUsageParser : NotificationUsageParser {
         val lines = record.text.lines()
         val secondLine = lines.getOrNull(1) ?: return null
         val amount = parseAmount(secondLine) ?: return null
-        val title = parseTitle(secondLine)
+        val title = parseTitle(secondLine).takeIf { it.isNotBlank() } ?: return null
 
         return NotificationUsageDraft(
             title = title,


### PR DESCRIPTION
## Summary
Added support for parsing Samsung Pay transaction notifications to extract payment amounts and merchant information.

## Changes
- **New Parser Implementation**: Created `SamsungPayNotificationUsageParser` that:
  - Targets Samsung Pay notifications (package: `com.samsung.android.spay`)
  - Extracts transaction amount using regex pattern matching for Japanese Yen (￥)
  - Extracts merchant/store name by removing the amount from the notification text
  - Converts notification timestamp to local datetime
  
- **Module Registration**: Registered the new parser in `NotificationUsageModule` with the Samsung Pay package name identifier

## Implementation Details
- The parser uses regex pattern `￥([0-9,]+)` to identify and extract amounts with comma-separated thousands
- Merchant name is derived by removing the amount pattern from the second line of the notification
- Follows the existing `NotificationUsageParser` interface pattern consistent with other payment service parsers (Suica, Saison Card, Google Wallet)

https://claude.ai/code/session_01Sm1QKfj9F6t2mExzmTXB9F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Samsung Pay通知から支払い情報を自動抽出できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->