### PR TITLE
通知から追加画面: 読み込み中に「一致なし」が表示される問題を修正

### DIFF
--- a/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/ui/NotificationUsageListScreen.kt
+++ b/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/ui/NotificationUsageListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
@@ -146,83 +147,97 @@ public fun NotificationUsageListScreen(
                     )
                 }
             }
-            if (uiState.items.isEmpty()) {
-                item {
-                    Text(
-                        text = uiState.emptyText,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
+            when (val itemsState = uiState.itemsState) {
+                NotificationUsageListScreenUiState.ItemsState.Loading -> {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxWidth(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
                 }
-            } else {
-                items(uiState.items) { item ->
-                    var showMenu by remember(item) { mutableStateOf(false) }
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        // Jetbrains Compose に combinedClickable がないため、clickable + semantics(customActions) での修正が必要。
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .then(
-                                    if (item.listener != null) {
-                                        Modifier.pointerInput(item) {
-                                            detectTapGestures(
-                                                onTap = {
-                                                    item.listener.onClick()
-                                                },
-                                                onLongPress = {
-                                                    showMenu = true
-                                                },
+                is NotificationUsageListScreenUiState.ItemsState.Loaded -> {
+                    if (itemsState.items.isEmpty()) {
+                        item {
+                            Text(
+                                text = itemsState.emptyText,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    } else {
+                        items(itemsState.items) { item ->
+                            var showMenu by remember(item) { mutableStateOf(false) }
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                // Jetbrains Compose に combinedClickable がないため、clickable + semantics(customActions) での修正が必要。
+                                Card(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .then(
+                                            if (item.listener != null) {
+                                                Modifier.pointerInput(item) {
+                                                    detectTapGestures(
+                                                        onTap = {
+                                                            item.listener.onClick()
+                                                        },
+                                                        onLongPress = {
+                                                            showMenu = true
+                                                        },
+                                                    )
+                                                }
+                                            } else {
+                                                Modifier
+                                            },
+                                        ),
+                                ) {
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(16.dp),
+                                    ) {
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                        ) {
+                                            Text(
+                                                modifier = Modifier.weight(1f),
+                                                text = item.title,
+                                                style = MaterialTheme.typography.titleSmall,
+                                            )
+                                            Spacer(modifier = Modifier.width(4.dp))
+                                            Text(
+                                                text = item.receivedAt,
+                                                style = MaterialTheme.typography.labelMedium,
+                                            )
+                                            Spacer(modifier = Modifier.width(8.dp))
+                                            Text(
+                                                text = item.statusLabel,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary,
                                             )
                                         }
-                                    } else {
-                                        Modifier
-                                    },
-                                ),
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(16.dp),
-                            ) {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
+                                        Spacer(modifier = Modifier.height(8.dp))
+                                        Text(
+                                            text = item.description,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                        )
+                                    }
+                                }
+                                DropdownMenu(
+                                    expanded = showMenu,
+                                    onDismissRequest = { showMenu = false },
                                 ) {
-                                    Text(
-                                        modifier = Modifier.weight(1f),
-                                        text = item.title,
-                                        style = MaterialTheme.typography.titleSmall,
-                                    )
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Text(
-                                        text = item.receivedAt,
-                                        style = MaterialTheme.typography.labelMedium,
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Text(
-                                        text = item.statusLabel,
-                                        style = MaterialTheme.typography.labelMedium,
-                                        color = MaterialTheme.colorScheme.primary,
+                                    DropdownMenuItem(
+                                        text = { Text("JSONでコピー") },
+                                        onClick = {
+                                            showMenu = false
+                                            item.listener?.onClickCopyJson()
+                                        },
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Text(
-                                    text = item.description,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
                             }
-                        }
-                        DropdownMenu(
-                            expanded = showMenu,
-                            onDismissRequest = { showMenu = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text("JSONでコピー") },
-                                onClick = {
-                                    showMenu = false
-                                    item.listener?.onClickCopyJson()
-                                },
-                            )
                         }
                     }
                 }

--- a/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/ui/NotificationUsageListScreenUiState.kt
+++ b/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/ui/NotificationUsageListScreenUiState.kt
@@ -6,14 +6,22 @@ import net.matsudamper.money.frontend.common.ui.base.KakeboScaffoldListener
 
 public data class NotificationUsageListScreenUiState(
     val title: String,
-    val items: ImmutableList<Item>,
+    val itemsState: ItemsState,
     val filters: ImmutableList<Filter>,
     val searchListener: SearchListener?,
-    val emptyText: String,
     val accessSection: AccessSection?,
     val topBarActions: ImmutableList<TopBarAction>,
     val kakeboScaffoldListener: KakeboScaffoldListener,
 ) {
+    public sealed interface ItemsState {
+        public data object Loading : ItemsState
+
+        public data class Loaded(
+            val items: ImmutableList<Item>,
+            val emptyText: String,
+        ) : ItemsState
+    }
+
     @Immutable
     public interface SearchListener {
         public fun onSearchQueryChange(query: String)

--- a/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/viewmodel/NotificationUsageViewModel.kt
+++ b/frontend/feature-notification/src/commonMain/kotlin/net/matsudamper/money/frontend/feature/notification/viewmodel/NotificationUsageViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -45,7 +44,7 @@ public class NotificationUsageViewModel(
         ViewModelState(
             status = initialStatus(mode),
             accessState = NotificationAccessState.NotGranted,
-            items = listOf(),
+            itemsLoadingState = ViewModelState.ItemsLoadingState.Loading,
         ),
     )
     private val copyJsonFormatter = Json {
@@ -55,10 +54,9 @@ public class NotificationUsageViewModel(
     public val uiStateFlow: StateFlow<NotificationUsageListScreenUiState> = MutableStateFlow(
         NotificationUsageListScreenUiState(
             title = modeTitle(mode),
-            items = listOf<NotificationUsageListScreenUiState.Item>().toImmutableList(),
+            itemsState = NotificationUsageListScreenUiState.ItemsState.Loading,
             filters = createStatusFilters(initialStatus(mode)).toImmutableList(),
             searchListener = createSearchListener(mode),
-            emptyText = emptyText(mode, initialStatus(mode)),
             accessSection = null,
             topBarActions = createTopBarActions(mode).toImmutableList(),
             kakeboScaffoldListener = object : KakeboScaffoldListener {
@@ -71,15 +69,25 @@ public class NotificationUsageViewModel(
         viewModelScope.launch {
             viewModelStateFlow.collectLatest { viewModelState ->
                 uiStateFlow.update { uiState ->
-                    val filteredItems = if (mode == Mode.NotificationList) {
-                        filterByQuery(viewModelState.items, viewModelState.searchQuery)
-                    } else {
-                        viewModelState.items
+                    val itemsState = when (val loadingState = viewModelState.itemsLoadingState) {
+                        ViewModelState.ItemsLoadingState.Loading -> {
+                            NotificationUsageListScreenUiState.ItemsState.Loading
+                        }
+                        is ViewModelState.ItemsLoadingState.Loaded -> {
+                            val filteredItems = if (mode == Mode.NotificationList) {
+                                filterByQuery(loadingState.items, viewModelState.searchQuery)
+                            } else {
+                                loadingState.items
+                            }
+                            NotificationUsageListScreenUiState.ItemsState.Loaded(
+                                items = filteredItems.map { createUiItem(it) }.toImmutableList(),
+                                emptyText = emptyText(mode, viewModelState.status),
+                            )
+                        }
                     }
                     uiState.copy(
-                        items = filteredItems.map { createUiItem(it) }.toImmutableList(),
+                        itemsState = itemsState,
                         filters = createStatusFilters(viewModelState.status).toImmutableList(),
-                        emptyText = emptyText(mode, viewModelState.status),
                         accessSection = createAccessSection(viewModelState.accessState),
                     )
                 }
@@ -97,9 +105,13 @@ public class NotificationUsageViewModel(
             viewModelStateFlow
                 .map { it.status }
                 .distinctUntilChanged()
-                .flatMapLatest { status -> itemsFlow(status) }
-                .collectLatest { items ->
-                    viewModelStateFlow.update { it.copy(items = items) }
+                .collectLatest { status ->
+                    viewModelStateFlow.update { it.copy(itemsLoadingState = ViewModelState.ItemsLoadingState.Loading) }
+                    itemsFlow(status).collectLatest { items ->
+                        viewModelStateFlow.update {
+                            it.copy(itemsLoadingState = ViewModelState.ItemsLoadingState.Loaded(items))
+                        }
+                    }
                 }
         }
     }
@@ -377,8 +389,14 @@ public class NotificationUsageViewModel(
         val status: Status,
         val searchQuery: String = "",
         val accessState: NotificationAccessState,
-        val items: List<ItemSource>,
+        val itemsLoadingState: ItemsLoadingState,
     ) {
+        sealed interface ItemsLoadingState {
+            data object Loading : ItemsLoadingState
+
+            data class Loaded(val items: List<ItemSource>) : ItemsLoadingState
+        }
+
         sealed interface ItemSource {
             data class Matched(val record: NotificationUsageMatchedRecord) : ItemSource
 


### PR DESCRIPTION
Closes #785

## 変更内容

- `ViewModelState.items`（`List<ItemSource>`）を `ItemsLoadingState` sealedクラス（`Loading` / `Loaded`）に変更
- `NotificationUsageListScreenUiState` の `items` と `emptyText` を `ItemsState` sealedインターフェースに統合（`Loading` / `Loaded`）
- ステータス切り替え時に `Loading` へリセットし、新しいFlowのデータが来るまでローディング状態を維持するよう修正
- UI側で `Loading` 状態のとき `CircularProgressIndicator` を表示するよう変更

## 修正前の問題

初期状態が空リスト（`listOf()`）だったため、非同期データ取得前にUIが空リストを「データなし」と判断し、「一致する未追加の通知はありません。」が表示されていた。

---
_Generated by [Claude Code](https://claude.ai/code/session_015CVmZyjE8pfvrPUf9vifDQ)_