### PR TITLE
PayPay通知パーサーの実装

### DIFF
--- a/.claude/skills/add-notification-parser/SKILL.md
+++ b/.claude/skills/add-notification-parser/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: add-notification-parser
+description: Guide for adding a new android local notification parser service.
+---
+
+# ローカルの通知パーサー追加ガイド
+
+## 実装のポイント
+
+- 個人情報を含めない。ユーザーから提供された文言を含めない

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/MobileSuicaNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/MobileSuicaNotificationUsageParser.kt
@@ -34,8 +34,7 @@ internal class MobileSuicaNotificationUsageParser : NotificationUsageParser {
     }
 
     private fun parseAmount(text: String): Int? {
-        // "-555円" や "-1,234円" のような利用金額を抽出する
-        // チャージ（プラスの値）や支払いなしの場合はマッチしない
+        // マイナス値のみマッチし、チャージ（プラス）・支払いなしは対象外
         val match = Regex("-([0-9,]+)円").find(text) ?: return null
         return match.groupValues[1].replace(",", "").toIntOrNull()
     }

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/NotificationUsageModule.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/NotificationUsageModule.kt
@@ -32,6 +32,7 @@ public object NotificationUsageModule {
         single<NotificationUsageParser>(named("jp.co.saisoncard.android.saisonportal")) { SaisonCardNotificationUsageParser() }
         single<NotificationUsageParser>(named("com.google.android.apps.walletnfcrel")) { GoogleWalletNotificationUsageParser() }
         single<NotificationUsageParser>(named("com.samsung.android.spay")) { SamsungPayNotificationUsageParser() }
+        single<NotificationUsageParser>(named("jp.ne.paypay.android.app")) { PayPayNotificationUsageParser() }
         single<NotificationUsageAutoAddApi> {
             NotificationUsageAutoAddGraphqlApi(
                 graphqlClient = get<GraphqlClient>(),

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/PayPayNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/PayPayNotificationUsageParser.kt
@@ -1,0 +1,47 @@
+package net.matsudamper.money.frontend.android.feature.notificationusage
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageDraft
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageFilterDefinition
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageParser
+import net.matsudamper.money.frontend.common.base.notification.NotificationUsageRecord
+
+internal class PayPayNotificationUsageParser : NotificationUsageParser {
+    override val filterDefinition: NotificationUsageFilterDefinition = NotificationUsageFilterDefinition(
+        id = "jp.ne.paypay.android.app",
+        title = "PayPay",
+        description = "PayPayの取引完了通知を解析します。利用金額・店舗名を抽出します。",
+    )
+
+    override fun parse(record: NotificationUsageRecord): NotificationUsageDraft? {
+        if (record.packageName != "jp.ne.paypay.android.app") return null
+
+        val lines = record.text.lines()
+        if (lines.getOrNull(1) != "取引が完了しました。") return null
+
+        val amount = parseAmount(record.text) ?: return null
+        val title = parseStoreName(record.text) ?: return null
+
+        return NotificationUsageDraft(
+            title = title,
+            description = record.text,
+            amount = amount,
+            dateTime = Instant.fromEpochMilliseconds(record.postedAtEpochMillis)
+                .toLocalDateTime(TimeZone.currentSystemDefault()),
+        )
+    }
+
+    private fun parseAmount(text: String): Int? {
+        // "金額：XXX円" のような利用金額を抽出する
+        val match = Regex("""金額：([0-9,]+)円""").find(text) ?: return null
+        return match.groupValues[1].replace(",", "").toIntOrNull()
+    }
+
+    private fun parseStoreName(text: String): String? {
+        // "店舗名：XXX" のような店舗名を抽出する
+        val match = Regex("""店舗名：(.+)""").find(text) ?: return null
+        return match.groupValues[1].trim()
+    }
+}

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/PayPayNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/PayPayNotificationUsageParser.kt
@@ -34,13 +34,11 @@ internal class PayPayNotificationUsageParser : NotificationUsageParser {
     }
 
     private fun parseAmount(text: String): Int? {
-        // "金額：XXX円" のような利用金額を抽出する
         val match = Regex("""金額：([0-9,]+)円""").find(text) ?: return null
         return match.groupValues[1].replace(",", "").toIntOrNull()
     }
 
     private fun parseStoreName(text: String): String? {
-        // "店舗名：XXX" のような店舗名を抽出する
         val match = Regex("""店舗名：(.+)""").find(text) ?: return null
         return match.groupValues[1].trim()
     }

--- a/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SaisonCardNotificationUsageParser.kt
+++ b/frontend/android/feature-notification-usage/src/main/kotlin/net/matsudamper/money/frontend/android/feature/notificationusage/SaisonCardNotificationUsageParser.kt
@@ -35,7 +35,6 @@ internal class SaisonCardNotificationUsageParser : NotificationUsageParser {
     }
 
     private fun parseAmount(text: String): Int? {
-        // "金額：3,111円" のような利用金額を抽出する
         val match = Regex("""金額：([0-9,]+)円""").find(text) ?: return null
         return match.groupValues[1].replace(",", "").toIntOrNull()
     }
@@ -46,7 +45,6 @@ internal class SaisonCardNotificationUsageParser : NotificationUsageParser {
     }
 
     private fun parseDateTime(text: String): LocalDateTime? {
-        // "日時：2020年5月22日 12時33分" のような利用日時を抽出する
         val match = Regex("""日時：(\d+)年(\d+)月(\d+)日\s+(\d+)時(\d+)分""").find(text) ?: return null
         val (year, month, day, hour, minute) = match.destructured
         return runCatching {


### PR DESCRIPTION
## 概要
PayPayアプリの取引完了通知をパースする機能を実装しました。

## 変更内容
- **PayPayNotificationUsageParser.kt**: 新規実装
  - PayPayの取引完了通知から利用金額と店舗名を抽出
  - 正規表現で「金額：」と「店舗名：」のパターンをマッチング
  - 通知の2行目が「取引が完了しました。」であることを確認して有効性を検証

- **NotificationUsageModule.kt**: PayPayパーサーをDIコンテナに登録
  - パッケージ名 `jp.ne.paypay.android.app` に対応するパーサーを追加

- **既存パーサーのコメント整理**
  - MobileSuicaNotificationUsageParser: parseAmount()のコメントを簡潔に修正
  - SaisonCardNotificationUsageParser: 冗長なコメントを削除

- **スキルドキュメント追加**: 通知パーサー実装時のガイドラインを記載
  - 個人情報やユーザー提供文言を含めないことを明記

## 実装の特徴
- 既存のNotificationUsageParserインターフェースに準拠
- 金額の3桁区切りカンマに対応
- 店舗名の前後の空白をトリムして抽出

https://claude.ai/code/session_01BdkShPnVSxTg6ZeRgwqGMV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PayPayアプリの取引通知を自動で解析し、取引金額と店舗名を自動抽出できるようになりました。

* **ドキュメント**
  * Android通知パーサーサービスの実装方法に関するドキュメントを新規作成しました。個人情報やユーザー提供文言を含めない実装方針も明記しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/kake-bo/pull/819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->