### PR TITLE
楽天カード利用先の半角カタカナを正規化

### DIFF
--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/lib/ParseUtil.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/lib/ParseUtil.kt
@@ -1,9 +1,9 @@
 package net.matsudamper.money.backend.mail.parser.lib
 
+import java.text.Normalizer
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.text.Normalizer
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.SignStyle
 import java.time.temporal.ChronoField

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/lib/ParseUtil.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/lib/ParseUtil.kt
@@ -3,6 +3,7 @@ package net.matsudamper.money.backend.mail.parser.lib
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.text.Normalizer
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.SignStyle
 import java.time.temporal.ChronoField
@@ -14,6 +15,26 @@ internal object ParseUtil {
             .mapNotNull { it.toString().toIntOrNull() }
             .joinToString("")
             .toIntOrNull()
+    }
+
+    fun normalizeHalfWidthKatakana(value: String): String {
+        val builder = StringBuilder()
+        var index = 0
+        while (index < value.length) {
+            val start = index
+            while (index < value.length && value[index].code in 0xFF61..0xFF9F) {
+                index++
+            }
+            if (index > start) {
+                builder.append(
+                    Normalizer.normalize(value.substring(start, index), Normalizer.Form.NFKC),
+                )
+            } else {
+                builder.append(value[index])
+                index++
+            }
+        }
+        return builder.toString()
     }
 
     fun removeHtmlTag(value: String): String {

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/RakutenCardUsageService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/RakutenCardUsageService.kt
@@ -62,7 +62,7 @@ internal object RakutenCardUsageService : MoneyUsageServices {
                     currentPrice = null
                 }
                 line.startsWith("■利用先:") -> {
-                    currentTitle = line.removePrefix("■利用先:").trim()
+                    currentTitle = ParseUtil.normalizeHalfWidthKatakana(line.removePrefix("■利用先:").trim())
                 }
                 line.startsWith("■利用金額:") -> {
                     currentPrice = ParseUtil.getInt(line.removePrefix("■利用金額:").trim())


### PR DESCRIPTION
## 概要
楽天カードのメールパーサで、利用先名に含まれる半角カタカナを全角カタカナに正規化するようにしました。

## 変更内容
- `ParseUtil`に`normalizeHalfWidthKatakana()`メソッドを追加
  - Unicode正規化形式NFKC（互換性分解と再合成）を使用して半角カタカナを全角に変換
  - 効率的な処理のため、半角カタカナ区間（U+FF61～U+FF9F）を検出して部分的に正規化
  
- `RakutenCardUsageService`で利用先名の抽出時に正規化を適用
  - `currentTitle`の設定時に`normalizeHalfWidthKatakana()`を呼び出し

## 実装の詳細
半角カタカナ区間を効率的に処理するため、文字列を走査しながら連続する半角カタカナ部分をまとめて正規化しています。これにより、不要な正規化処理を避けることができます。

https://claude.ai/code/session_01BkC8fb9mg72o6M39wUYt3V