### PR TITLE
Web版の起動時クラッシュを修正

### DIFF
--- a/frontend/app/src/jsMain/kotlin/lib/compose/HtmlOverLay.kt
+++ b/frontend/app/src/jsMain/kotlin/lib/compose/HtmlOverLay.kt
@@ -15,7 +15,6 @@ import net.matsudamper.money.frontend.common.ui.layout.html.text.fullscreen.Loca
 import org.jetbrains.compose.web.css.Color
 import org.jetbrains.compose.web.css.DisplayStyle
 import org.jetbrains.compose.web.css.FlexDirection
-import org.jetbrains.compose.web.css.Position
 import org.jetbrains.compose.web.css.backgroundColor
 import org.jetbrains.compose.web.css.color
 import org.jetbrains.compose.web.css.cssRem
@@ -23,14 +22,11 @@ import org.jetbrains.compose.web.css.display
 import org.jetbrains.compose.web.css.flexDirection
 import org.jetbrains.compose.web.css.flexGrow
 import org.jetbrains.compose.web.css.height
-import org.jetbrains.compose.web.css.outline
 import org.jetbrains.compose.web.css.overflow
 import org.jetbrains.compose.web.css.padding
 import org.jetbrains.compose.web.css.percent
-import org.jetbrains.compose.web.css.position
 import org.jetbrains.compose.web.css.width
 import org.jetbrains.compose.web.dom.Button
-import org.jetbrains.compose.web.dom.Canvas
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Iframe
 import org.jetbrains.compose.web.dom.Text
@@ -38,56 +34,38 @@ import org.jetbrains.compose.web.renderComposable
 
 @Suppress("FunctionName")
 internal fun JsCompose(composeSize: StateFlow<IntSize>) {
-    renderComposable(rootElementId = "ComposeTargetContainer") {
-        Canvas(
-            attrs = {
-                id("ComposeTarget")
-                style {
-                    width(100.percent)
-                    height(100.percent)
-                    position(Position.Absolute)
-                    outline("none")
-                    // Compose1.5.10に上げたらスマホでここが解除されなくなった。無くても動いたので一旦コメントアウト
-//                    if (hasFullScreenOverlay) {
-//                        property(
-//                            "pointer-events",
-//                            "none",
-//                        )
-//                    }
-                }
-            },
-        )
-    }
-
     renderComposable(rootElementId = "HtmlComposeTarget") {
         val widthDensityState: MutableState<Float?> = remember { mutableStateOf(null) }
         val heightDensityState: MutableState<Float?> = remember { mutableStateOf(null) }
         LaunchedEffect(Unit) {
-            val htmlComposeTarget = document.getElementById("ComposeTarget")!!
-            ResizeObserver { entries, _ ->
-                val target = entries[0].target
+            // ComposeViewportが描画するcanvasはShadow DOM内にあるため、サイズの基準には常に存在するコンテナを観測する
+            val composeTargetContainer = document.getElementById("ComposeTargetContainer")
+            if (composeTargetContainer != null) {
+                ResizeObserver { entries, _ ->
+                    val target = entries[0].target
 
-                widthDensityState.value = run {
-                    val jsWidth = target.scrollWidth.toFloat()
-                    val composeWidth = composeSize.value.width.toFloat()
+                    widthDensityState.value = run {
+                        val jsWidth = target.scrollWidth.toFloat()
+                        val composeWidth = composeSize.value.width.toFloat()
 
-                    if (jsWidth > 0 && composeWidth > 0) {
-                        jsWidth / composeWidth
-                    } else {
-                        1f
+                        if (jsWidth > 0 && composeWidth > 0) {
+                            jsWidth / composeWidth
+                        } else {
+                            1f
+                        }
                     }
-                }
-                heightDensityState.value = run {
-                    val jsSize = target.scrollHeight.toFloat()
-                    val composeHeight = composeSize.value.height.toFloat()
+                    heightDensityState.value = run {
+                        val jsSize = target.scrollHeight.toFloat()
+                        val composeHeight = composeSize.value.height.toFloat()
 
-                    if (jsSize > 0 && composeHeight > 0) {
-                        jsSize / composeHeight
-                    } else {
-                        1f
+                        if (jsSize > 0 && composeHeight > 0) {
+                            jsSize / composeHeight
+                        } else {
+                            1f
+                        }
                     }
-                }
-            }.observe(htmlComposeTarget)
+                }.observe(composeTargetContainer)
+            }
         }
 
         val htmlRenderContextState by LocalHtmlRenderContext.current.stateFlow.collectAsState()

--- a/frontend/app/src/jsMain/kotlin/lib/js/NormalizeInputKeyCapture.kt
+++ b/frontend/app/src/jsMain/kotlin/lib/js/NormalizeInputKeyCapture.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.onFocusChanged
 import kotlinx.browser.document
+import kotlinx.coroutines.delay
+import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.events.KeyboardEvent
 
 @Composable
@@ -23,7 +25,7 @@ public fun NormalizeInputKeyCapture(content: @Composable () -> Unit) {
         mutableStateOf(false)
     }
     LaunchedEffect(Unit) {
-        val target = document.getElementById("ComposeTarget")!!
+        val target = awaitComposeCanvas()
         target.addEventListener(
             type = "keydown",
             callback = { event ->
@@ -51,4 +53,30 @@ public fun NormalizeInputKeyCapture(content: @Composable () -> Unit) {
     ) {
         content()
     }
+}
+
+// ComposeViewportはviewportContainer配下のShadow DOM内にidの無いcanvasを生成するため、走査して取得する
+private suspend fun awaitComposeCanvas(): HTMLCanvasElement {
+    while (true) {
+        val canvas = findComposeCanvas()
+        if (canvas != null) {
+            return canvas
+        }
+        delay(50)
+    }
+}
+
+private fun findComposeCanvas(): HTMLCanvasElement? {
+    val container = document.getElementById("ComposeTargetContainer") ?: return null
+    val divs = container.getElementsByTagName("div")
+    for (index in 0 until divs.length) {
+        val shadowRoot = divs.item(index)?.asDynamic()?.shadowRoot
+        if (shadowRoot != null) {
+            val canvas = shadowRoot.querySelector("canvas")
+            if (canvas != null) {
+                return canvas.unsafeCast<HTMLCanvasElement>()
+            }
+        }
+    }
+    return null
 }


### PR DESCRIPTION
## 概要

Web版が起動直後にクラッシュし、画面が描画されない問題を修正しました。

## 原因

`ComposeViewport` への移行に伴い、旧 `CanvasBasedWindow` 前提だったキャンバス参照のコードが破綻していました。現在の `ComposeViewport` は描画用キャンバスをShadow DOM内に生成するため、従来の固定IDによるキャンバス取得が常に失敗し、起動時のエフェクト内で例外が発生してComposition全体が停止していました。

なお、当初疑われたComposeのバージョン不整合は原因ではありませんでした（現状のバージョン構成は妥当です）。

## 対応方針

- キーボード入力の捕捉処理を、実際の描画キャンバスへ追従するように変更
- HTMLオーバーレイのサイズ基準を、常に存在するコンテナ要素へ変更し、不要になった旧来のキャンバス生成を削除

## 動作確認

バックエンドを起動せず、ビルド成果物をブラウザで読み込んで確認しました。

- 修正前: 起動時に未処理例外が発生し、何も描画されない
- 修正後: 例外なくUIが描画され、バックエンド未接続時は接続エラー画面が正しく表示される

## テスト

- [ ] CIでのビルド確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVcKjyKR9UKwDBbq7i9HmS)_