### PR TITLE
パスワード有無に応じて設定画面のボタンを切り替える

### DIFF
--- a/backend/app/interfaces/src/jvmMain/kotlin/net/matsudamper/money/backend/app/interfaces/UserLoginRepository.kt
+++ b/backend/app/interfaces/src/jvmMain/kotlin/net/matsudamper/money/backend/app/interfaces/UserLoginRepository.kt
@@ -3,6 +3,8 @@ package net.matsudamper.money.backend.app.interfaces
 import net.matsudamper.money.element.UserId
 
 interface UserLoginRepository {
+    fun hasPassword(userId: UserId): Boolean
+
     sealed interface Result {
         data class Success(val uerId: UserId) : Result
 

--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/UserSettingsResolverImpl.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/UserSettingsResolverImpl.kt
@@ -19,6 +19,18 @@ import net.matsudamper.money.graphql.model.QlUserSettings
 import net.matsudamper.money.graphql.model.UserSettingsResolver
 
 class UserSettingsResolverImpl : UserSettingsResolver {
+    override fun hasPassword(
+        userSettings: QlUserSettings,
+        env: DataFetchingEnvironment,
+    ): CompletionStage<DataFetcherResult<Boolean>> {
+        val context = env.graphQlContext.get<GraphQlContext>(GraphQlContext::class.java.name)
+        val userId = context.verifyUserSessionAndGetUserId()
+
+        return otelSupplyAsync {
+            context.diContainer.userLoginRepository().hasPassword(userId)
+        }.toDataFetcher()
+    }
+
     override fun imapConfig(
         userSettings: QlUserSettings,
         env: DataFetchingEnvironment,

--- a/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbUserLoginRepository.kt
+++ b/backend/datasource/db/src/jvmMain/kotlin/net/matsudamper/money/backend/datasource/db/repository/DbUserLoginRepository.kt
@@ -19,6 +19,16 @@ class DbUserLoginRepository(
     private val userPasswordExtendData = JUserPasswordExtendData.USER_PASSWORD_EXTEND_DATA
     private val bases64Encoder = Base64.getEncoder()
 
+    override fun hasPassword(userId: UserId): Boolean {
+        return dbConnection.use {
+            DSL.using(it)
+                .selectCount()
+                .from(userPasswords)
+                .where(userPasswords.USER_ID.eq(userId.value))
+                .fetchOne(0, Int::class.java)
+        }?.let { it > 0 } ?: false
+    }
+
     override fun getLoginEncryptInfo(userName: String): UserLoginRepository.LoginEncryptInfo? {
         val result = dbConnection.use {
             DSL.using(it)

--- a/backend/graphql/src/commonMain/resources/graphql/user_setting.graphqls
+++ b/backend/graphql/src/commonMain/resources/graphql/user_setting.graphqls
@@ -4,6 +4,7 @@ type UserSettings {
     registeredFidoList: [RegisteredFidoInfo!]! @lazy
     sessionAttributes: SessionAttributes!
     apiTokenAttributes: ApiTokenAttributes!
+    hasPassword: Boolean! @lazy
 }
 
 type ApiTokenAttributes {

--- a/frontend/common/graphql/schema/src/commonMain/graphql/login_setting_screen.graphql
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/login_setting_screen.graphql
@@ -1,6 +1,7 @@
 query LoginSettingScreen {
     user {
         settings {
+            hasPassword
             registeredFidoList {
                 id
                 name

--- a/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
@@ -903,6 +903,8 @@ type UserSettings {
   sessionAttributes: SessionAttributes!
 
   apiTokenAttributes: ApiTokenAttributes!
+
+  hasPassword: Boolean!
 }
 
 type __Directive {

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/LoginSettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/LoginSettingScreen.kt
@@ -125,6 +125,8 @@ public data class LoginSettingScreenUiState(
     ) {
         @Immutable
         public interface Event {
+            public fun onClickAddPassword()
+
             public fun onClickChangePassword()
 
             public fun onClickDeletePassword()
@@ -713,19 +715,28 @@ private fun PasswordCardContent(
             }
         }
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-        PasswordActionRow(
-            iconRes = Res.drawable.ic_edit,
-            text = "パスワードを変更",
-            color = MaterialTheme.colorScheme.primary,
-            onClick = { password.event.onClickChangePassword() },
-        )
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-        PasswordActionRow(
-            iconRes = Res.drawable.ic_delete,
-            text = "パスワードを削除",
-            color = MaterialTheme.colorScheme.error,
-            onClick = { password.event.onClickDeletePassword() },
-        )
+        if (password.isRegistered) {
+            PasswordActionRow(
+                iconRes = Res.drawable.ic_edit,
+                text = "パスワードを変更",
+                color = MaterialTheme.colorScheme.primary,
+                onClick = { password.event.onClickChangePassword() },
+            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            PasswordActionRow(
+                iconRes = Res.drawable.ic_delete,
+                text = "パスワードを削除",
+                color = MaterialTheme.colorScheme.error,
+                onClick = { password.event.onClickDeletePassword() },
+            )
+        } else {
+            PasswordActionRow(
+                iconRes = Res.drawable.ic_add,
+                text = "パスワードを追加",
+                color = MaterialTheme.colorScheme.primary,
+                onClick = { password.event.onClickAddPassword() },
+            )
+        }
     }
 }
 

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingViewModel.kt
@@ -106,11 +106,15 @@ public class LoginSettingViewModel(
                                 }.toImmutableList()
                             }
                         },
-                        password = LoginSettingScreenUiState.Password(
-                            isRegistered = true,
-                            maskedDisplay = "••••••••",
-                            event = PasswordEventImpl(),
-                        ),
+                        password = run password@{
+                            val hasPassword = viewModelState.apolloScreenResponse
+                                ?.data?.user?.settings?.hasPassword ?: false
+                            LoginSettingScreenUiState.Password(
+                                isRegistered = hasPassword,
+                                maskedDisplay = "••••••••",
+                                event = PasswordEventImpl(),
+                            )
+                        },
                         sessionList = run sessionList@{
                             val sessionList = viewModelState.apolloScreenResponse
                                 ?.data?.user?.settings?.sessionAttributes?.sessions
@@ -348,6 +352,10 @@ public class LoginSettingViewModel(
     private inner class PasswordEventImpl :
         LoginSettingScreenUiState.Password.Event,
         EqualsImpl() {
+        override fun onClickAddPassword() {
+            // TODO: パスワード追加機能は未実装
+        }
+
         override fun onClickChangePassword() {
             // TODO: パスワード変更機能は未実装
         }


### PR DESCRIPTION
## 概要

管理者がパスワードを削除した場合に、ユーザーの「設定 > パスワード」画面で「パスワードを削除」ではなく「パスワードを追加」ボタンを表示する。

## 変更内容

### バックエンド（GraphQL）
- `user_setting.graphqls`: `UserSettings` 型に `hasPassword: Boolean! @lazy` を追加
- `UserLoginRepository`: `hasPassword(userId: UserId): Boolean` をインターフェースに追加
- `DbUserLoginRepository`: `USER_PASSWORDS` テーブルのレコード有無で実装
- `UserSettingsResolverImpl`: `hasPassword` リゾルバを追加

### フロントエンド
- `login_setting_screen.graphql`: `hasPassword` フィールドをクエリに追加
- `schema.graphqls`(frontend): `UserSettings` に `hasPassword` を追加
- `LoginSettingScreen`: `isRegistered` に応じてボタンを切り替え
  - `true`（パスワードあり）: 「パスワードを変更」「パスワードを削除」を表示
  - `false`（パスワードなし）: 「パスワードを追加」のみ表示
- `LoginSettingViewModel`: `hasPassword` を API レスポンスから取得、`onClickAddPassword()` を TODO で追加

https://claude.ai/code/session_011z8TWE1cfJyrmSVWcbYgw1