### PR TITLE
パスワードの追加・変更・削除機能を追加

### DIFF
--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/mutation/SettingsMutationResolverResolverImpl.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/mutation/SettingsMutationResolverResolverImpl.kt
@@ -7,12 +7,68 @@ import net.matsudamper.money.backend.graphql.GraphQlContext
 import net.matsudamper.money.backend.graphql.otelSupplyAsync
 import net.matsudamper.money.backend.graphql.otelThenApplyAsync
 import net.matsudamper.money.backend.graphql.toDataFetcher
+import net.matsudamper.money.backend.logic.PasswordManager
+import net.matsudamper.money.backend.logic.ReplacePasswordUseCase
+import net.matsudamper.money.graphql.model.QlChangePasswordErrorType
+import net.matsudamper.money.graphql.model.QlChangePasswordResult
 import net.matsudamper.money.graphql.model.QlSettingsMutation
 import net.matsudamper.money.graphql.model.QlUpdateUserImapConfigInput
 import net.matsudamper.money.graphql.model.QlUserImapConfig
 import net.matsudamper.money.graphql.model.SettingsMutationResolver
 
 class SettingsMutationResolverResolverImpl : SettingsMutationResolver {
+    override fun changePassword(
+        settingsMutation: QlSettingsMutation,
+        password: String?,
+        env: DataFetchingEnvironment,
+    ): CompletionStage<DataFetcherResult<QlChangePasswordResult>> {
+        val context = env.graphQlContext.get<GraphQlContext>(GraphQlContext::class.java.name)
+        val userId = context.verifyUserSessionAndGetUserId()
+        return otelSupplyAsync {
+            val result = ReplacePasswordUseCase(
+                context.diContainer.createAdminRepository(),
+                passwordManager = PasswordManager(),
+            ).replacePassword(
+                userId = userId,
+                password = password,
+            )
+            when (result) {
+                is ReplacePasswordUseCase.Result.Failure -> {
+                    val errorType = result.errors.map {
+                        when (it) {
+                            is ReplacePasswordUseCase.Result.Errors.InternalServerError -> {
+                                QlChangePasswordErrorType.Unknown
+                            }
+
+                            is ReplacePasswordUseCase.Result.Errors.PasswordLength -> {
+                                QlChangePasswordErrorType.PasswordLength
+                            }
+
+                            is ReplacePasswordUseCase.Result.Errors.PasswordValidation -> {
+                                QlChangePasswordErrorType.PasswordInvalidChar
+                            }
+
+                            ReplacePasswordUseCase.Result.Errors.UserNotFound -> {
+                                QlChangePasswordErrorType.UserNotFound
+                            }
+                        }
+                    }
+                    QlChangePasswordResult(
+                        isSuccess = false,
+                        errorType = errorType.firstOrNull(),
+                    )
+                }
+
+                is ReplacePasswordUseCase.Result.Success -> {
+                    QlChangePasswordResult(
+                        isSuccess = true,
+                        errorType = null,
+                    )
+                }
+            }
+        }.toDataFetcher()
+    }
+
     override fun updateImapConfig(
         settingsMutation: QlSettingsMutation,
         config: QlUpdateUserImapConfigInput,

--- a/backend/graphql/src/commonMain/resources/graphql/user_mutation.graphqls
+++ b/backend/graphql/src/commonMain/resources/graphql/user_mutation.graphqls
@@ -184,6 +184,19 @@ type UserLoginResult {
 
 type SettingsMutation {
     updateImapConfig(config: UpdateUserImapConfigInput!) : UserImapConfig
+    changePassword(password: String): ChangePasswordResult! @lazy
+}
+
+type ChangePasswordResult {
+    isSuccess: Boolean!
+    errorType: ChangePasswordErrorType
+}
+
+enum ChangePasswordErrorType {
+    Unknown,
+    UserNotFound,
+    PasswordLength,
+    PasswordInvalidChar,
 }
 
 input UpdateUserImapConfigInput {

--- a/frontend/common/graphql/schema/src/commonMain/graphql/login_setting_screen.graphql
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/login_setting_screen.graphql
@@ -73,6 +73,19 @@ mutation LoginSettingScreenDeleteSession(
     }
 }
 
+mutation LoginSettingScreenChangePassword(
+    $password: String
+) {
+    userMutation {
+        settingsMutation {
+            changePassword(password: $password) {
+                isSuccess
+                errorType
+            }
+        }
+    }
+}
+
 query LoginSettingScreenGetFidoInfo {
     user {
         settings {

--- a/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/schema.graphqls
@@ -642,6 +642,19 @@ scalar SessionRecordId
 
 type SettingsMutation {
   updateImapConfig(config: UpdateUserImapConfigInput!): UserImapConfig
+  changePassword(password: String): ChangePasswordResult!
+}
+
+type ChangePasswordResult {
+  isSuccess: Boolean!
+  errorType: ChangePasswordErrorType
+}
+
+enum ChangePasswordErrorType {
+  Unknown
+  UserNotFound
+  PasswordLength
+  PasswordInvalidChar
 }
 
 """

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/LoginSettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/LoginSettingScreen.kt
@@ -137,9 +137,15 @@ public data class LoginSettingScreenUiState(
         val title: String,
         val text: String,
         val type: TextFieldType,
-        val onConfirm: (String) -> Unit,
-        val onCancel: () -> Unit,
-    )
+        val event: Event,
+    ) {
+        @Immutable
+        public interface Event {
+            public fun onConfirm(text: String)
+
+            public fun onCancel()
+        }
+    }
 
     public data class Fido(
         val name: String,
@@ -172,8 +178,8 @@ public fun LoginSettingScreen(
             title = uiState.textInputDialogState.title,
             default = uiState.textInputDialogState.text,
             inputType = uiState.textInputDialogState.type,
-            onComplete = { uiState.textInputDialogState.onConfirm(it) },
-            canceled = { uiState.textInputDialogState.onCancel() },
+            onComplete = { uiState.textInputDialogState.event.onConfirm(it) },
+            canceled = { uiState.textInputDialogState.event.onCancel() },
         )
     }
     uiState.confirmDialog?.also { dialog ->

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingScreenApi.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingScreenApi.kt
@@ -3,6 +3,7 @@ package net.matsudamper.money.frontend.common.viewmodel.root.settings.login
 import kotlinx.coroutines.flow.Flow
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.apolloStore
 import com.apollographql.apollo.cache.normalized.fetchPolicy
@@ -10,12 +11,14 @@ import com.apollographql.apollo.cache.normalized.watch
 import net.matsudamper.money.element.FidoId
 import net.matsudamper.money.element.SessionRecordId
 import net.matsudamper.money.frontend.common.base.Logger
+import net.matsudamper.money.frontend.graphql.LoginSettingScreenChangePasswordMutation
 import net.matsudamper.money.frontend.graphql.LoginSettingScreenChangeSessionNameMutation
 import net.matsudamper.money.frontend.graphql.LoginSettingScreenDeleteSessionMutation
 import net.matsudamper.money.frontend.graphql.LoginSettingScreenLogoutMutation
 import net.matsudamper.money.frontend.graphql.LoginSettingScreenQuery
 import net.matsudamper.money.frontend.graphql.SettingScreenAddFidoMutation
 import net.matsudamper.money.frontend.graphql.SettingScreenDeleteFidoMutation
+import net.matsudamper.money.frontend.graphql.type.ChangePasswordErrorType
 import net.matsudamper.money.frontend.graphql.type.RegisterFidoInput
 
 private const val TAG = "LoginSettingScreenApi"
@@ -109,5 +112,41 @@ public class LoginSettingScreenApi(
         }.onFailure {
             Logger.e(TAG, it)
         }.getOrNull() ?: false
+    }
+
+    public suspend fun changePassword(password: String?): ChangePasswordResult {
+        val result = runCatching {
+            apolloClient
+                .mutation(
+                    LoginSettingScreenChangePasswordMutation(password = Optional.present(password)),
+                )
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+                .data?.userMutation?.settingsMutation?.changePassword
+        }.onFailure {
+            Logger.e(TAG, it)
+        }.getOrNull()
+
+        return if (result == null) {
+            ChangePasswordResult.Failed
+        } else if (result.isSuccess) {
+            ChangePasswordResult.Success
+        } else {
+            when (result.errorType) {
+                ChangePasswordErrorType.PasswordLength -> ChangePasswordResult.PasswordLength
+                ChangePasswordErrorType.PasswordInvalidChar -> ChangePasswordResult.PasswordInvalidChar
+                else -> ChangePasswordResult.Failed
+            }
+        }
+    }
+
+    public sealed interface ChangePasswordResult {
+        public data object Success : ChangePasswordResult
+
+        public data object PasswordLength : ChangePasswordResult
+
+        public data object PasswordInvalidChar : ChangePasswordResult
+
+        public data object Failed : ChangePasswordResult
     }
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingViewModel.kt
@@ -353,15 +353,73 @@ public class LoginSettingViewModel(
         LoginSettingScreenUiState.Password.Event,
         EqualsImpl() {
         override fun onClickAddPassword() {
-            // TODO: パスワード追加機能は未実装
+            showPasswordInputDialog(title = "パスワードを入力してください")
         }
 
         override fun onClickChangePassword() {
-            // TODO: パスワード変更機能は未実装
+            showPasswordInputDialog(title = "新しいパスワードを入力してください")
         }
 
         override fun onClickDeletePassword() {
-            // TODO: パスワード削除機能は未実装
+            showConfirmDialog(
+                title = "パスワードを削除",
+                description = "パスワードを削除しますか？",
+                onConfirm = { changePassword(null) },
+            )
+        }
+
+        private fun showPasswordInputDialog(title: String) {
+            val dialogState = LoginSettingScreenUiState.TextInputDialogState(
+                title = title,
+                text = "",
+                onConfirm = { password ->
+                    closeTextInputDialog()
+                    if (password.isBlank()) {
+                        showToast("入力してください")
+                    } else {
+                        changePassword(password)
+                    }
+                },
+                onCancel = {
+                    closeTextInputDialog()
+                },
+                type = TextFieldType.Password,
+            )
+            viewModelStateFlow.update {
+                it.copy(
+                    textInputDialogState = dialogState,
+                )
+            }
+        }
+
+        private fun changePassword(password: String?) {
+            viewModelScope.launch {
+                val result = api.changePassword(password)
+                when (result) {
+                    LoginSettingScreenApi.ChangePasswordResult.Success -> {
+                        showToast(if (password == null) "削除しました" else "保存しました")
+                        api.getScreen().first()
+                    }
+
+                    LoginSettingScreenApi.ChangePasswordResult.PasswordLength -> {
+                        showToast("パスワードの長さが不正です")
+                    }
+
+                    LoginSettingScreenApi.ChangePasswordResult.PasswordInvalidChar -> {
+                        showToast("使用できない文字が含まれています")
+                    }
+
+                    LoginSettingScreenApi.ChangePasswordResult.Failed -> {
+                        showToast("失敗しました")
+                    }
+                }
+            }
+        }
+
+        private fun showToast(text: String) {
+            viewModelScope.launch {
+                eventSender.send { it.showToast(text) }
+            }
         }
     }
 

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/login/LoginSettingViewModel.kt
@@ -192,53 +192,29 @@ public class LoginSettingViewModel(
                 showAddFidoFailToast()
                 return@launch
             }
-            val onConfirm: (String) -> Unit = { name ->
-                viewModelScope.launch onConfirm@{
-                    if (name.isBlank()) {
-                        eventSender.send { it.showToast("入力してください") }
-                        return@onConfirm
-                    }
-                    val result = withContext(Dispatchers.Default) {
-                        api.addFido(
-                            displayName = name,
-                            base64AttestationObject = createResult.attestationObjectBase64,
-                            base64ClientDataJson = createResult.clientDataJSONBase64,
-                            challenge = fidoInfo.challenge,
-                        )
-                    }
-
-                    val registerFidoResult = result?.data?.userMutation?.registerFido
-                    if (registerFidoResult?.fidoInfo == null) {
-                        showAddFidoFailToast()
-                    } else {
-                        eventSender.send { it.showToast("追加しました") }
-                        api.getScreen().first()
-                    }
-                    viewModelStateFlow.update { viewModelState ->
-                        viewModelState.copy(
-                            textInputDialogState = null,
-                        )
-                    }
-                }
-            }
-            val onCancel: () -> Unit = {
-                viewModelStateFlow.update { viewModelState ->
-                    viewModelState.copy(
-                        textInputDialogState = null,
-                    )
-                }
-            }
             viewModelStateFlow.update { viewModelState ->
                 viewModelState.copy(
                     textInputDialogState = LoginSettingScreenUiState.TextInputDialogState(
                         title = "キーの名前を入力してください",
                         text = "",
-                        onConfirm = onConfirm,
-                        onCancel = onCancel,
+                        event = FidoNameInputDialogEventImpl(
+                            base64AttestationObject = createResult.attestationObjectBase64,
+                            base64ClientDataJson = createResult.clientDataJSONBase64,
+                            challenge = fidoInfo.challenge,
+                        ),
                         type = TextFieldType.Text,
                     ),
                 )
             }
+        }
+    }
+
+    private suspend fun refreshScreen() {
+        val response = api.getScreen().first()
+        viewModelStateFlow.update { viewModelState ->
+            viewModelState.copy(
+                apolloScreenResponse = response,
+            )
         }
     }
 
@@ -310,7 +286,7 @@ public class LoginSettingViewModel(
                 val result = api.deleteSession(id)
                 if (result) {
                     eventSender.send { it.showToast("削除しました") }
-                    api.getScreen().first()
+                    refreshScreen()
                 } else {
                     eventSender.send { it.showToast("削除に失敗しました") }
                 }
@@ -318,21 +294,14 @@ public class LoginSettingViewModel(
         }
 
         override fun onClickNameChange() {
-            val dialogState = LoginSettingScreenUiState.TextInputDialogState(
-                title = "名前を入力してください",
-                text = name,
-                onConfirm = {
-                    changeName(it)
-                    closeTextInputDialog()
-                },
-                onCancel = {
-                    closeTextInputDialog()
-                },
-                type = TextFieldType.Text,
-            )
             viewModelStateFlow.update {
                 it.copy(
-                    textInputDialogState = dialogState,
+                    textInputDialogState = LoginSettingScreenUiState.TextInputDialogState(
+                        title = "名前を入力してください",
+                        text = name,
+                        event = NameInputDialogEventImpl(),
+                        type = TextFieldType.Text,
+                    ),
                 )
             }
         }
@@ -341,10 +310,23 @@ public class LoginSettingViewModel(
             viewModelScope.launch {
                 val result = api.changeSessionName(id = id, name = newName)
                 if (result) {
-                    api.getScreen().first()
+                    refreshScreen()
                 } else {
                     eventSender.send { it.showToast("変更に失敗しました") }
                 }
+            }
+        }
+
+        private inner class NameInputDialogEventImpl :
+            LoginSettingScreenUiState.TextInputDialogState.Event,
+            EqualsImpl(id) {
+            override fun onConfirm(text: String) {
+                changeName(text)
+                closeTextInputDialog()
+            }
+
+            override fun onCancel() {
+                closeTextInputDialog()
             }
         }
     }
@@ -369,25 +351,14 @@ public class LoginSettingViewModel(
         }
 
         private fun showPasswordInputDialog(title: String) {
-            val dialogState = LoginSettingScreenUiState.TextInputDialogState(
-                title = title,
-                text = "",
-                onConfirm = { password ->
-                    closeTextInputDialog()
-                    if (password.isBlank()) {
-                        showToast("入力してください")
-                    } else {
-                        changePassword(password)
-                    }
-                },
-                onCancel = {
-                    closeTextInputDialog()
-                },
-                type = TextFieldType.Password,
-            )
             viewModelStateFlow.update {
                 it.copy(
-                    textInputDialogState = dialogState,
+                    textInputDialogState = LoginSettingScreenUiState.TextInputDialogState(
+                        title = title,
+                        text = "",
+                        event = PasswordInputDialogEventImpl(),
+                        type = TextFieldType.Password,
+                    ),
                 )
             }
         }
@@ -398,7 +369,7 @@ public class LoginSettingViewModel(
                 when (result) {
                     LoginSettingScreenApi.ChangePasswordResult.Success -> {
                         showToast(if (password == null) "削除しました" else "保存しました")
-                        api.getScreen().first()
+                        refreshScreen()
                     }
 
                     LoginSettingScreenApi.ChangePasswordResult.PasswordLength -> {
@@ -420,6 +391,59 @@ public class LoginSettingViewModel(
             viewModelScope.launch {
                 eventSender.send { it.showToast(text) }
             }
+        }
+
+        private inner class PasswordInputDialogEventImpl :
+            LoginSettingScreenUiState.TextInputDialogState.Event,
+            EqualsImpl() {
+            override fun onConfirm(text: String) {
+                closeTextInputDialog()
+                if (text.isBlank()) {
+                    showToast("入力してください")
+                } else {
+                    changePassword(text)
+                }
+            }
+
+            override fun onCancel() {
+                closeTextInputDialog()
+            }
+        }
+    }
+
+    private inner class FidoNameInputDialogEventImpl(
+        private val base64AttestationObject: String,
+        private val base64ClientDataJson: String,
+        private val challenge: String,
+    ) : LoginSettingScreenUiState.TextInputDialogState.Event, EqualsImpl(challenge) {
+        override fun onConfirm(text: String) {
+            viewModelScope.launch onConfirm@{
+                if (text.isBlank()) {
+                    eventSender.send { it.showToast("入力してください") }
+                    return@onConfirm
+                }
+                val result = withContext(Dispatchers.Default) {
+                    api.addFido(
+                        displayName = text,
+                        base64AttestationObject = base64AttestationObject,
+                        base64ClientDataJson = base64ClientDataJson,
+                        challenge = challenge,
+                    )
+                }
+
+                val registerFidoResult = result?.data?.userMutation?.registerFido
+                if (registerFidoResult?.fidoInfo == null) {
+                    showAddFidoFailToast()
+                } else {
+                    eventSender.send { it.showToast("追加しました") }
+                    refreshScreen()
+                }
+                closeTextInputDialog()
+            }
+        }
+
+        override fun onCancel() {
+            closeTextInputDialog()
         }
     }
 


### PR DESCRIPTION
## 概要

ログイン設定画面から、ユーザー自身がパスワードを追加・変更・削除できるようにしました。GraphQLスキーマを起点に実装しています。

## 変更内容

### バックエンド
- **スキーマ** (`user_mutation.graphqls`): `SettingsMutation` に `changePassword(password: String): ChangePasswordResult!` を追加。`password` を nullable にし、値あり＝追加/変更、null＝削除を1つのミューテーションで表現。エラー列挙型 `ChangePasswordErrorType` は既存の `AdminReplacePasswordErrorType` の命名規約に合わせました。
- **Resolver** (`SettingsMutationResolverResolverImpl.kt`): 既存の `ReplacePasswordUseCase` を現在のセッションユーザーID (`verifyUserSessionAndGetUserId()`) で再利用。パスワード検証・ハッシュ化・保存はUseCaseに委譲。

### フロントエンド
- **スキーマ/オペレーション**: ダウンロード済みスキーマに同定義を追記し、`LoginSettingScreenChangePassword` ミューテーションを追加。
- **API** (`LoginSettingScreenApi.kt`): `changePassword()` を実装し、結果を `ChangePasswordResult`（Success/PasswordLength/PasswordInvalidChar/Failed）にマッピング。
- **ViewModel** (`LoginSettingViewModel.kt`): TODOだった `PasswordEventImpl` を実装。追加・変更はパスワード入力ダイアログ、削除は確認ダイアログを表示し、結果に応じてトースト表示・画面再取得を行う。

## 検証

- `./gradlew :backend:assemble :frontend:app:jsBrowserDevelopmentWebpack` → 成功
- 対象モジュールの ktlintFormat → 成功（差分なし）
- ⚠️ 当該環境にAndroid SDKが未導入のため、`:frontend:app:assembleDebug` は未確認です。編集箇所はcommonMain/jvmのみです。

https://claude.ai/code/session_01HNhoRDPKppPgHCkpGkscet

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNhoRDPKppPgHCkpGkscet)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ユーザー設定画面からパスワードの変更・削除が可能になりました。成功時は画面を再取得して反映します。

* **Bug Fixes**
  * パスワード変更処理の結果に応じたエラー種別を導入し、長さ不正・無効文字・ユーザー未存在・その他の失敗を適切にハンドリングして表示します。
  * 入力ダイアログの挙動と通知（トースト）表示を整理しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/kake-bo/pull/834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->