### PR TITLE
メール転送情報を解析して日時と送信者情報を取得

### DIFF
--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/lib/ParseUtil.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/lib/ParseUtil.kt
@@ -52,9 +52,10 @@ internal object ParseUtil {
         val forwardedStartIndex = lines.indexOf("---------- Forwarded message ---------")
             .takeIf { it >= 0 } ?: return null
 
-        val forwardedEndIndex = lines.subList(forwardedStartIndex, lines.size)
+        val relativeForwardedEndIndex = lines.subList(forwardedStartIndex, lines.size)
             .indexOf("")
             .takeIf { it >= 0 } ?: return null
+        val forwardedEndIndex = forwardedStartIndex + relativeForwardedEndIndex
 
         val forwardedMetadata = lines.subList(forwardedStartIndex, forwardedEndIndex)
             .associate {

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/AmazonCoJpUsageServices.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/AmazonCoJpUsageServices.kt
@@ -19,25 +19,27 @@ internal object AmazonCoJpUsageServices : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
             yield(canHandledWithPlain(plain))
         }
         if (canHandle.any { it }.not()) return listOf()
 
+        val resolvedDate = forwardedInfo?.date ?: date
         return buildList {
             addAll(
                 parseA(
                     plain = plain,
                     html = html,
-                    date = date,
+                    date = resolvedDate,
                 ),
             )
             addAll(
                 parseB(
                     plain = plain,
-                    date = date,
+                    date = resolvedDate,
                 ),
             )
             if (isEmpty()) {
@@ -47,7 +49,7 @@ internal object AmazonCoJpUsageServices : MoneyUsageServices {
                         price = null,
                         description = "パースできませんでした",
                         service = MoneyUsageServiceType.Amazon,
-                        dateTime = date,
+                        dateTime = resolvedDate,
                     ),
                 )
             }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/DmmUsageServices.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/DmmUsageServices.kt
@@ -18,9 +18,10 @@ internal object DmmUsageServices : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
         }
         if (canHandle.any { it }.not()) return listOf()
 
@@ -51,7 +52,7 @@ internal object DmmUsageServices : MoneyUsageServices {
                 price = parsedPrice,
                 description = "",
                 service = MoneyUsageServiceType.Dmm,
-                dateTime = parsedDate ?: date,
+                dateTime = parsedDate ?: forwardedInfo?.date ?: date,
             ),
         )
     }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/ESekiReserveUsegeService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/ESekiReserveUsegeService.kt
@@ -6,6 +6,7 @@ import java.time.LocalTime
 import net.matsudamper.money.backend.base.element.MoneyUsageServiceType
 import net.matsudamper.money.backend.mail.parser.MoneyUsage
 import net.matsudamper.money.backend.mail.parser.MoneyUsageServices
+import net.matsudamper.money.backend.mail.parser.lib.ParseUtil
 
 internal object ESekiReserveUsegeService : MoneyUsageServices {
     override val displayName: String = "e席リザーブ"
@@ -17,9 +18,10 @@ internal object ESekiReserveUsegeService : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
             yield(canHandledWithPlain(plain))
         }
         if (canHandle.any { it }.not()) return listOf()
@@ -102,7 +104,7 @@ internal object ESekiReserveUsegeService : MoneyUsageServices {
                 price = price,
                 description = description,
                 service = MoneyUsageServiceType.ESekiReserve,
-                dateTime = parsedDate ?: date,
+                dateTime = parsedDate ?: forwardedInfo?.date ?: date,
             ),
         )
     }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/FanzaDojinUsageServices.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/FanzaDojinUsageServices.kt
@@ -16,10 +16,11 @@ internal object FanzaDojinUsageServices : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         return parsePlain(
             // plainが無く、htmlにplainが含まれている場合がある
             plain = plain.takeIf { it.isNotBlank() } ?: html,
-            date = date,
+            date = forwardedInfo?.date ?: date,
         )
     }
 

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/FanzaDojinUsageServices.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/FanzaDojinUsageServices.kt
@@ -16,10 +16,11 @@ internal object FanzaDojinUsageServices : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
-        val forwardedInfo = ParseUtil.parseForwarded(plain)
+        // plainが無く、htmlにplainが含まれている場合がある
+        val effectivePlain = plain.takeIf { it.isNotBlank() } ?: html
+        val forwardedInfo = ParseUtil.parseForwarded(effectivePlain)
         return parsePlain(
-            // plainが無く、htmlにplainが含まれている場合がある
-            plain = plain.takeIf { it.isNotBlank() } ?: html,
+            plain = effectivePlain,
             date = forwardedInfo?.date ?: date,
         )
     }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/GooglePlayUsageService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/GooglePlayUsageService.kt
@@ -6,6 +6,7 @@ import java.time.LocalTime
 import net.matsudamper.money.backend.base.element.MoneyUsageServiceType
 import net.matsudamper.money.backend.mail.parser.MoneyUsage
 import net.matsudamper.money.backend.mail.parser.MoneyUsageServices
+import net.matsudamper.money.backend.mail.parser.lib.ParseUtil
 
 public object GooglePlayUsageService : MoneyUsageServices {
     override val displayName: String = "Google"
@@ -17,9 +18,10 @@ public object GooglePlayUsageService : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
             yield(canHandledWithPlain(plain))
         }
         if (canHandle.any { it }.not()) return listOf()
@@ -93,7 +95,7 @@ public object GooglePlayUsageService : MoneyUsageServices {
                 price = price,
                 description = "seller: $seller",
                 service = MoneyUsageServiceType.GooglePlay,
-                dateTime = parsedDate ?: date,
+                dateTime = parsedDate ?: forwardedInfo?.date ?: date,
             ),
         )
     }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/MacdonaldsMobileOrderUsageService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/MacdonaldsMobileOrderUsageService.kt
@@ -4,6 +4,7 @@ import java.time.LocalDateTime
 import net.matsudamper.money.backend.base.element.MoneyUsageServiceType
 import net.matsudamper.money.backend.mail.parser.MoneyUsage
 import net.matsudamper.money.backend.mail.parser.MoneyUsageServices
+import net.matsudamper.money.backend.mail.parser.lib.ParseUtil
 
 internal object MacdonaldsMobileOrderUsageService : MoneyUsageServices {
     override val displayName: String = "マクドナルド"
@@ -15,8 +16,9 @@ internal object MacdonaldsMobileOrderUsageService : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
             yield(canHandledWithPlain(plain))
         }
         if (canHandle.any { it }.not()) return listOf()
@@ -48,7 +50,7 @@ internal object MacdonaldsMobileOrderUsageService : MoneyUsageServices {
         return listOf(
             MoneyUsage(
                 title = displayName,
-                dateTime = date,
+                dateTime = forwardedInfo?.date ?: date,
                 price = price,
                 service = MoneyUsageServiceType.Macdonalds,
                 description = description.orEmpty(),

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/MovieTicketUsageService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/MovieTicketUsageService.kt
@@ -6,6 +6,7 @@ import java.time.LocalTime
 import net.matsudamper.money.backend.base.element.MoneyUsageServiceType
 import net.matsudamper.money.backend.mail.parser.MoneyUsage
 import net.matsudamper.money.backend.mail.parser.MoneyUsageServices
+import net.matsudamper.money.backend.mail.parser.lib.ParseUtil
 
 public object MovieTicketUsageService : MoneyUsageServices {
     override val displayName: String = "ムビチケ"
@@ -17,9 +18,10 @@ public object MovieTicketUsageService : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
             yield(canHandledWithPlain(plain))
         }
         if (canHandle.any { it }.not()) return listOf()
@@ -60,7 +62,7 @@ public object MovieTicketUsageService : MoneyUsageServices {
                 price = price,
                 description = "",
                 service = MoneyUsageServiceType.MovieTicket,
-                dateTime = parsedDate ?: date,
+                dateTime = parsedDate ?: forwardedInfo?.date ?: date,
             ),
         )
     }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/ShunsuguUsageService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/ShunsuguUsageService.kt
@@ -16,9 +16,10 @@ internal object ShunsuguUsageService : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
             yield(canHandledWithPlain(plain))
         }
         if (canHandle.any { it }.not()) return listOf()
@@ -51,7 +52,7 @@ internal object ShunsuguUsageService : MoneyUsageServices {
                 price = price,
                 description = description,
                 service = MoneyUsageServiceType.Shunsugu,
-                dateTime = date,
+                dateTime = forwardedInfo?.date ?: date,
             ),
         )
     }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/SquareEnixMogStationUsageServices.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/SquareEnixMogStationUsageServices.kt
@@ -58,7 +58,7 @@ internal object SquareEnixMogStationUsageServices : MoneyUsageServices {
                         "${it.title} ${it.price}円"
                     },
                     service = MoneyUsageServiceType.FFXIV,
-                    dateTime = date,
+                    dateTime = forwardedInfo?.date ?: date,
                 ),
             )
             addAll(products)

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/SquareEnixMogStationUsageServices.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/SquareEnixMogStationUsageServices.kt
@@ -16,9 +16,10 @@ internal object SquareEnixMogStationUsageServices : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
         }
         if (canHandle.any { it }.not()) return listOf()
         val lines = ParseUtil.splitByNewLine(plain)
@@ -40,7 +41,7 @@ internal object SquareEnixMogStationUsageServices : MoneyUsageServices {
                         price = price,
                         description = description,
                         service = MoneyUsageServiceType.FFXIV,
-                        dateTime = date,
+                        dateTime = forwardedInfo?.date ?: date,
                     ),
                 )
             }

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/UberEatsUsageService.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/services/UberEatsUsageService.kt
@@ -17,9 +17,10 @@ internal object UberEatsUsageService : MoneyUsageServices {
         plain: String,
         date: LocalDateTime,
     ): List<MoneyUsage> {
+        val forwardedInfo = ParseUtil.parseForwarded(plain)
         val canHandle = sequence {
-            yield(canHandledWithFrom(from))
-            yield(canHandledWithSubject(subject))
+            yield(canHandledWithFrom(forwardedInfo?.from ?: from))
+            yield(canHandledWithSubject(forwardedInfo?.subject ?: subject))
             yield(canHandledWithHtml(html))
         }
         if (canHandle.any { it }.not()) return listOf()
@@ -50,7 +51,7 @@ internal object UberEatsUsageService : MoneyUsageServices {
                 price = price,
                 description = "",
                 service = MoneyUsageServiceType.UberEats,
-                dateTime = date,
+                dateTime = forwardedInfo?.date ?: date,
             ),
         )
     }


### PR DESCRIPTION
## 概要
メール転送時に元のメール情報が失われる問題に対応するため、複数のメールパーサーサービスに `ParseUtil.parseForwarded()` を導入し、転送されたメールから元の送信者情報と日時を抽出して使用するようにしました。

## 主な変更点

- **AmazonCoJpUsageServices**: 転送情報を解析し、送信者・件名・日時を取得して使用
- **ESekiReserveUsegeService**: 転送情報から日時を取得し、パース失敗時のフォールバックとして使用
- **GooglePlayUsageService**: 転送情報から日時を取得し、パース失敗時のフォールバックとして使用
- **MovieTicketUsageService**: 転送情報から日時を取得し、パース失敗時のフォールバックとして使用
- **DmmUsageServices**: 転送情報から日時を取得し、パース失敗時のフォールバックとして使用
- **ShunsuguUsageService**: 転送情報から日時を取得して使用
- **SquareEnixMogStationUsageServices**: 転送情報から日時を取得して使用
- **UberEatsUsageService**: 転送情報から日時を取得して使用
- **MacdonaldsMobileOrderUsageService**: 転送情報から日時を取得して使用
- **FanzaDojinUsageServices**: 転送情報から日時を取得して使用

## 実装の詳細

各サービスで以下のパターンで対応しています：

1. `ParseUtil.parseForwarded(plain)` で転送情報を解析
2. 送信者・件名の判定時に `forwardedInfo?.from ?: from` のように転送情報を優先
3. 日時の設定時に `forwardedInfo?.date ?: date` のように転送情報を優先、またはパース結果を優先

これにより、メールが転送された場合でも元のメール情報に基づいて正確に家計簿データを登録できるようになります。

https://claude.ai/code/session_01CRiHsyrkBZ8sr3DEsFcy6s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 転送されたメールから送信者、件名、日付情報の抽出精度を向上させました。
  * 複数の取引サービス（Amazon、DMM、Google Play、UberEats等）において、転送メール内の情報を優先的に活用するようにしました。これにより、転送されたメールからの取引情報解析の精度が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->