### PR TITLE
メール転送情報をパースして日時と送信者を抽出

### DIFF
--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/RegisterMailHandler.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/RegisterMailHandler.kt
@@ -11,6 +11,7 @@ import net.matsudamper.money.backend.di.DiContainer
 import net.matsudamper.money.backend.logic.ApiTokenEncryptManager
 import net.matsudamper.money.backend.logic.IPasswordManager
 import net.matsudamper.money.backend.logic.PasswordManager
+import net.matsudamper.money.backend.mail.parser.MailParser as ServiceMailParser
 
 class RegisterMailHandler(
     private val diContainer: DiContainer,
@@ -36,14 +37,16 @@ class RegisterMailHandler(
             ?: return Result.Forbidden
 
         val mail = MailParser.rawContentToResponse(request.raw)
+        val plainText = mail.content.filterIsInstance<MailResult.Content.Text>().firstOrNull()?.text
+        val forwardedInfo = plainText?.let { ServiceMailParser.forwardedInfo(it) }
 
         val addResult = importedMailRepository.addMail(
             userId = verifyResult.userId,
-            plainText = mail.content.filterIsInstance<MailResult.Content.Text>().firstOrNull()?.text,
+            plainText = plainText,
             html = mail.content.filterIsInstance<MailResult.Content.Html>().firstOrNull()?.html,
-            from = mail.from.firstOrNull() ?: "",
+            from = forwardedInfo?.from ?: mail.from.firstOrNull() ?: "",
             subject = mail.subject,
-            dateTime = LocalDateTime.ofInstant(mail.sendDate, ZoneOffset.UTC),
+            dateTime = forwardedInfo?.dateTime ?: LocalDateTime.ofInstant(mail.sendDate, ZoneOffset.UTC),
         )
 
         return when (addResult) {

--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/UserMailAttributesResolverImpl.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/resolver/UserMailAttributesResolverImpl.kt
@@ -10,6 +10,7 @@ import net.matsudamper.money.backend.base.element.MailResult
 import net.matsudamper.money.backend.graphql.GraphQlContext
 import net.matsudamper.money.backend.graphql.otelSupplyAsync
 import net.matsudamper.money.backend.graphql.toDataFetcher
+import net.matsudamper.money.backend.mail.parser.MailParser as ServiceMailParser
 import net.matsudamper.money.graphql.model.QlMailQuery
 import net.matsudamper.money.graphql.model.QlUserMail
 import net.matsudamper.money.graphql.model.QlUserMailAttributes
@@ -62,16 +63,21 @@ class UserMailAttributesResolverImpl : UserMailAttributesResolver {
                 usrMails = mails.map { mail ->
                     val html = mail.content.filterIsInstance<MailResult.Content.Html>()
                     val text = mail.content.filterIsInstance<MailResult.Content.Text>()
+                    val forwardedInfo = text.firstOrNull()?.text?.let { ServiceMailParser.forwardedInfo(it) }
 
                     // TODO: mail.forwardedForの先頭を見て、許可されているメールだけを取り込むようにする
                     QlUserMail(
                         id = mail.messageID,
                         plain = text.getOrNull(0)?.text,
                         html = html.getOrNull(0)?.html,
-                        time = OffsetDateTime.ofInstant(mail.sendDate, ZoneOffset.UTC),
+                        time = if (forwardedInfo != null) {
+                            OffsetDateTime.of(forwardedInfo.dateTime, ZoneOffset.UTC)
+                        } else {
+                            OffsetDateTime.ofInstant(mail.sendDate, ZoneOffset.UTC)
+                        },
                         subject = mail.subject,
                         sender = mail.sender,
-                        from = mail.from,
+                        from = if (forwardedInfo != null) listOf(forwardedInfo.from) else mail.from,
                     )
                 },
                 cursor = if (mails.isEmpty()) {

--- a/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/usecase/ImportMailUseCase.kt
+++ b/backend/app/src/jvmMain/kotlin/net/matsudamper/money/backend/graphql/usecase/ImportMailUseCase.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import net.matsudamper.money.backend.app.interfaces.ImportedMailRepository
 import net.matsudamper.money.backend.base.element.MailResult
 import net.matsudamper.money.backend.di.DiContainer
+import net.matsudamper.money.backend.mail.parser.MailParser as ServiceMailParser
 import net.matsudamper.money.element.MailId
 import net.matsudamper.money.element.UserId
 
@@ -35,14 +36,16 @@ class ImportMailUseCase(
                 mailRepository.getMails(mailIds).map { mail ->
                     val html = mail.content.filterIsInstance<MailResult.Content.Html>()
                     val text = mail.content.filterIsInstance<MailResult.Content.Text>()
+                    val plainText = text.firstOrNull()?.text
+                    val forwardedInfo = plainText?.let { ServiceMailParser.forwardedInfo(it) }
 
                     val result = dbMailRepository.addMail(
                         userId = userId,
                         subject = mail.subject,
-                        plainText = text.firstOrNull()?.text,
+                        plainText = plainText,
                         html = html.firstOrNull()?.html,
-                        dateTime = LocalDateTime.ofInstant(mail.sendDate, ZoneOffset.UTC),
-                        from = mail.from.firstOrNull().orEmpty(),
+                        dateTime = forwardedInfo?.dateTime ?: LocalDateTime.ofInstant(mail.sendDate, ZoneOffset.UTC),
+                        from = forwardedInfo?.from ?: mail.from.firstOrNull().orEmpty(),
                     )
 
                     when (result) {

--- a/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/MailParser.kt
+++ b/backend/feature/service_mail_parser/src/jvmMain/kotlin/net/matsudamper/money/backend/mail/parser/MailParser.kt
@@ -142,7 +142,7 @@ public object MailParser {
         val info = ParseUtil.parseForwarded(text) ?: return null
         return ForwardedInfo(
             from = info.from ?: return null,
-            subject = info.subject ?: return null,
+            subject = info.subject.orEmpty(),
             dateTime = info.date ?: return null,
         )
     }


### PR DESCRIPTION
## 概要
メール本文から転送情報をパースし、転送元のメールの日時と送信者を抽出して使用するように変更しました。

## 主な変更
- `ServiceMailParser.forwardedInfo()`を使用してメール本文から転送情報を抽出
- 転送情報が存在する場合、以下の値を転送元のものに置き換え：
  - メール日時：`mail.sendDate` → `forwardedInfo.dateTime`
  - 送信者：`mail.from` → `forwardedInfo.from`
- 3つのファイルで同様の処理を実装：
  - `UserMailAttributesResolverImpl.kt`：GraphQL resolver
  - `RegisterMailHandler.kt`：メール登録ハンドラー
  - `ImportMailUseCase.kt`：メールインポートユースケース

## 実装の詳細
- 各ファイルで`MailParser as ServiceMailParser`として別名インポートし、既存の`MailParser`クラスとの競合を回避
- 転送情報の抽出は一度だけ行い、変数に保存して複数回の参照を効率化
- 転送情報がない場合は元の値を使用するフォールバック処理を実装

https://claude.ai/code/session_01AkeDAoanGZ6vJUV1CQFaEs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 転送メールの送信者と送信日時を転送元情報から抽出するよう改善しました。転送されたメール内の情報を正確に認識し、メール属性をより正確に表示できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->