### PR TITLE
月次画面にプルトゥリフレッシュ機能を追加

### DIFF
--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
@@ -22,9 +22,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,6 +35,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +48,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import coil3.compose.SubcomposeAsyncImage
 import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.base.ImmutableList.Companion.toImmutableList
@@ -102,9 +109,11 @@ public data class RootHomeMonthlyScreenUiState(
         public suspend fun onViewInitialized()
         public fun onSortTypeChanged(sortType: SortSectionType)
         public fun onSortOrderChanged(order: SortSectionOrder)
+        public suspend fun refresh()
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 public fun RootHomeMonthlyScreen(
     uiState: RootHomeMonthlyScreenUiState,
@@ -115,29 +124,46 @@ public fun RootHomeMonthlyScreen(
     LaunchedEffect(Unit) {
         uiState.event.onViewInitialized()
     }
-    when (val loadingState = uiState.loadingState) {
-        is RootHomeMonthlyScreenUiState.LoadingState.Loaded -> {
-            LoadedContent(
-                modifier = modifier.fillMaxSize(),
-                loadingState = loadingState,
-                uiState = uiState,
-                showImages = showImages,
-            )
-        }
-
-        RootHomeMonthlyScreenUiState.LoadingState.Loading -> {
-            Box(modifier = modifier.fillMaxSize()) {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+    val pullToRefreshState = rememberPullToRefreshState()
+    val coroutineScope = rememberCoroutineScope()
+    var isRefreshing by remember { mutableStateOf(false) }
+    PullToRefreshBox(
+        modifier = modifier.fillMaxSize(),
+        state = pullToRefreshState,
+        isRefreshing = isRefreshing,
+        onRefresh = {
+            coroutineScope.launch {
+                isRefreshing = true
+                uiState.event.refresh()
+                delay(1000.milliseconds)
+                isRefreshing = false
             }
-        }
+        },
+    ) {
+        when (val loadingState = uiState.loadingState) {
+            is RootHomeMonthlyScreenUiState.LoadingState.Loaded -> {
+                LoadedContent(
+                    modifier = Modifier.fillMaxSize(),
+                    loadingState = loadingState,
+                    uiState = uiState,
+                    showImages = showImages,
+                )
+            }
 
-        RootHomeMonthlyScreenUiState.LoadingState.Error -> {
-            LoadingErrorContent(
-                modifier = modifier.fillMaxWidth(),
-                onClickRetry = {
-                    // TODO
-                },
-            )
+            RootHomeMonthlyScreenUiState.LoadingState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+            }
+
+            RootHomeMonthlyScreenUiState.LoadingState.Error -> {
+                LoadingErrorContent(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClickRetry = {
+                        // TODO
+                    },
+                )
+            }
         }
     }
 }
@@ -375,6 +401,7 @@ private fun RootHomeMonthlyScreenPreviewContent(isDarkTheme: Boolean) {
                     override suspend fun onViewInitialized() {}
                     override fun onSortTypeChanged(sortType: SortSectionType) {}
                     override fun onSortOrderChanged(order: SortSectionOrder) {}
+                    override suspend fun refresh() {}
                 },
                 currentSortType = SortSectionType.Date,
                 sortOrder = SortSectionOrder.Descending,

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
@@ -128,6 +128,10 @@ public class RootHomeMonthlyScreenViewModel(
                         order = order,
                     )
                 }
+
+                override suspend fun refresh() {
+                    fetchFromNetwork()
+                }
             },
         ),
     ).also { uiStateFlow ->
@@ -238,6 +242,28 @@ public class RootHomeMonthlyScreenViewModel(
         viewModelScope.launch {
             fetch()
         }
+    }
+
+    private suspend fun fetchFromNetwork() {
+        val sinceDateTime = createSinceLocalDateTime()
+        val untilDateTime = LocalDateTime(
+            date = sinceDateTime.date.plus(1, DateTimeUnit.MONTH),
+            time = sinceDateTime.time,
+        )
+        val analyticsResponse = graphqlClient.apolloClient.query(
+            MonthlyScreenQuery(
+                sinceDateTime = sinceDateTime,
+                untilDateTime = untilDateTime,
+            ),
+        ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+        viewModelStateFlow.value = viewModelStateFlow.value.copy(
+            moneyUsageAnalytics = analyticsResponse.data?.user?.moneyUsageAnalytics,
+        )
+
+        val firstQuery = getFirstQueryFlow().value
+        graphqlClient.apolloClient.query(firstQuery)
+            .fetchPolicy(FetchPolicy.NetworkOnly)
+            .execute()
     }
 
     private suspend fun fetch() {

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
@@ -256,9 +256,12 @@ public class RootHomeMonthlyScreenViewModel(
                 untilDateTime = untilDateTime,
             ),
         ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
-        viewModelStateFlow.value = viewModelStateFlow.value.copy(
-            moneyUsageAnalytics = analyticsResponse.data?.user?.moneyUsageAnalytics,
-        )
+        val moneyUsageAnalytics = analyticsResponse.data?.user?.moneyUsageAnalytics
+        if (moneyUsageAnalytics != null) {
+            viewModelStateFlow.value = viewModelStateFlow.value.copy(
+                moneyUsageAnalytics = moneyUsageAnalytics,
+            )
+        }
 
         val firstQuery = getFirstQueryFlow().value
         graphqlClient.apolloClient.query(firstQuery)


### PR DESCRIPTION
## 概要
月次画面にプルトゥリフレッシュ機能を実装しました。ユーザーが画面を下にドラッグすることでデータを更新できるようになります。

## 主な変更点

### UI層 (`RootHomeMonthlyScreen.kt`)
- Material3の`PullToRefreshBox`を導入し、プルトゥリフレッシュ機能を実装
- `rememberPullToRefreshState()`と`rememberCoroutineScope()`を使用して状態管理
- リフレッシュ中の状態を`isRefreshing`で管理し、1秒のディレイを設定
- 既存のコンテンツを`PullToRefreshBox`でラップ
- プレビュー用の`Event`実装に`refresh()`メソッドを追加

### ViewModel層 (`RootHomeMonthlyScreenViewModel.kt`)
- `Event`インターフェースに`suspend fun refresh()`メソッドを追加
- `fetchFromNetwork()`メソッドを新規実装
  - ネットワークからのみデータを取得するよう`FetchPolicy.NetworkOnly`を指定
  - 月次分析データと最初のクエリを更新
- `refresh()`イベントハンドラーで`fetchFromNetwork()`を呼び出し

## 実装の詳細
- `@OptIn(ExperimentalMaterial3Api::class)`アノテーションを追加してExperimental APIを使用
- リフレッシュ完了後に1秒のディレイを設定することで、ユーザーに視覚的フィードバックを提供
- キャッシュをバイパスして常に最新データを取得するため、`FetchPolicy.NetworkOnly`を使用

https://claude.ai/code/session_01RnShC3thxgqdLBdWRHDhmc