### PR TITLE
キャッシュ戦略の改善とリフレッシュ機能の統合

### DIFF
--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/ImportedMailCategoryFilterScreenPagingModel.kt
@@ -1,12 +1,15 @@
 package net.matsudamper.money.frontend.common.viewmodel.root.settings.categoryfilters
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.withContext
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.apolloStore
 import com.apollographql.apollo.cache.normalized.fetchPolicy
 import com.apollographql.apollo.cache.normalized.watch
+import net.matsudamper.money.frontend.common.base.IO
 import net.matsudamper.money.frontend.common.base.nav.ScopedObjectFeature
 import net.matsudamper.money.frontend.common.viewmodel.CommonViewModel
 import net.matsudamper.money.frontend.graphql.GraphqlClient
@@ -32,30 +35,14 @@ public class ImportedMailCategoryFilterScreenPagingModel(
 
     internal fun getFlow(): Flow<ApolloResponse<ImportedMailCategoryFiltersScreenPagingQuery.Data>> {
         return graphqlClient.apolloClient.query(firstQuery)
-            .fetchPolicy(FetchPolicy.CacheFirst)
+            .fetchPolicy(FetchPolicy.CacheOnly)
             .watch()
+            .filter { it.data != null }
     }
 
-    internal suspend fun refresh(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
-        return runCatching {
-            val response = graphqlClient.apolloClient.query(firstQuery)
-                .fetchPolicy(FetchPolicy.NetworkOnly)
-                .execute()
-            val data = response.data
-                ?: return UpdateOperationResponseResult.Error(NullPointerException("ApolloResponse.data is null"))
-            graphqlClient.apolloClient.apolloStore.writeOperation(
-                operation = firstQuery,
-                operationData = data,
-                customScalarAdapters = graphqlClient.apolloClient.customScalarAdapters,
-                publish = true,
-            )
-            UpdateOperationResponseResult.Success(response)
-        }.getOrElse { UpdateOperationResponseResult.Error(it) }
-    }
-
-    internal suspend fun fetch(): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
+    internal suspend fun fetch(isForceRefresh: Boolean = false): UpdateOperationResponseResult<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
         return graphqlClient.apolloClient.updateOperation(firstQuery) update@{ before ->
-            if (before == null) return@update success(fetchPage(cursor = null))
+            if (before == null || isForceRefresh) return@update success(fetchPage(cursor = null))
             if (before.user?.importedMailCategoryFilters?.isLast == true) return@update noHasMore()
 
             val cursor = before.user?.importedMailCategoryFilters?.cursor ?: return@update error()
@@ -83,15 +70,19 @@ public class ImportedMailCategoryFilterScreenPagingModel(
     }
 
     private suspend fun fetchPage(cursor: String?): ApolloResponse<ImportedMailCategoryFiltersScreenPagingQuery.Data> {
-        return graphqlClient.apolloClient.query(
-            query = ImportedMailCategoryFiltersScreenPagingQuery(
-                query = ImportedMailCategoryFiltersQuery(
-                    cursor = Optional.present(cursor),
-                    isAsc = true,
-                    size = Optional.present(10),
-                    sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
+        return withContext(Dispatchers.IO) {
+            graphqlClient.apolloClient.query(
+                query = ImportedMailCategoryFiltersScreenPagingQuery(
+                    query = ImportedMailCategoryFiltersQuery(
+                        cursor = Optional.present(cursor),
+                        isAsc = true,
+                        size = Optional.present(10),
+                        sortType = Optional.present(ImportedMailCategoryFiltersSortType.TITLE),
+                    ),
                 ),
-            ),
-        ).execute()
+            )
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .execute()
+        }
     }
 }

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/settings/categoryfilters/SettingMailCategoryFiltersViewModel.kt
@@ -39,7 +39,7 @@ public class SettingMailCategoryFiltersViewModel(
         override fun onPullToRefresh() {
             viewModelScope.launch {
                 viewModelStateFlow.update { it.copy(isRefreshing = true) }
-                val result = pagingModel.refresh()
+                val result = pagingModel.fetch(isForceRefresh = true)
                 viewModelStateFlow.update {
                     it.copy(lastLoadingState = result, isRefreshing = false)
                 }
@@ -62,7 +62,7 @@ public class SettingMailCategoryFiltersViewModel(
                         runCatching {
                             api.addFilter(text)
                         }.onSuccess {
-                            val result = pagingModel.refresh()
+                            val result = pagingModel.fetch(isForceRefresh = true)
                             viewModelStateFlow.update {
                                 it.copy(lastLoadingState = result)
                             }


### PR DESCRIPTION
## 概要
ImportedMailCategoryFilterScreenPagingModelのキャッシュ戦略を改善し、リフレッシュ機能を統合しました。キャッシュのみを使用する方式に変更し、明示的なリフレッシュ時のみネットワークアクセスを行うようにしました。

## 主な変更

- **キャッシュ戦略の変更**: `FetchPolicy.CacheFirst`から`FetchPolicy.CacheOnly`に変更し、常にキャッシュからデータを取得するように統一
- **リフレッシュ機能の統合**: 独立していた`refresh()`メソッドを削除し、`fetch()`メソッドに`isForceRefresh`パラメータを追加して統合
- **フロー処理の改善**: `watch()`の結果に`.filter { it.data != null }`を追加し、nullデータを除外
- **ネットワークアクセスの最適化**: `fetchPage()`メソッドを`Dispatchers.IO`コンテキストで実行し、`FetchPolicy.NetworkOnly`を明示的に指定
- **呼び出し元の更新**: `SettingMailCategoryFiltersViewModel`の`onPullToRefresh()`と`addFilter()`内で`pagingModel.refresh()`を`pagingModel.fetch(isForceRefresh = true)`に変更

## 実装の詳細

- キャッシュ戦略を単純化することで、データの一貫性を保ちながらネットワークアクセスを最小化
- `updateOperation()`を使用したページング処理により、初回取得時またはリフレッシュ時のみネットワークアクセスを実行
- IO操作を適切なディスパッチャーで実行することでスレッド安全性を確保

https://claude.ai/code/session_01VsEv7WbkCN5NjmNLZ1uJDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノーツ

* **リファクタリング**
  * メールカテゴリフィルター設定画面のページング処理と更新機能を改善しました。内部的なデータ管理をより効率化し、より安定した動作と応答性の向上を実現しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->