### PR TITLE
カテゴリに色を付けて月別画面に表示

### DIFF
--- a/frontend/common/graphql/schema/src/commonMain/graphql/monthly_screen.graphql
+++ b/frontend/common/graphql/schema/src/commonMain/graphql/monthly_screen.graphql
@@ -52,6 +52,10 @@ query MonthlyScreenList(
                 moneyUsageSubCategory {
                     id
                     name
+                    category {
+                        id
+                        name
+                    }
                 }
             }
         }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
@@ -258,21 +258,6 @@ private fun LoadedContent(
                             Column(
                                 modifier = Modifier.padding(horizontal = padding),
                             ) {
-                                if (item.category.isNotEmpty()) {
-                                    Text(
-                                        modifier = Modifier
-                                            .background(
-                                                color = item.categoryColor,
-                                                shape = RoundedCornerShape(4.dp),
-                                            )
-                                            .padding(horizontal = 8.dp, vertical = 2.dp),
-                                        text = item.category,
-                                        maxLines = 1,
-                                        color = Color.White,
-                                        style = MaterialTheme.typography.labelSmall,
-                                    )
-                                    Spacer(modifier = Modifier.height(4.dp))
-                                }
                                 Text(
                                     text = item.date,
                                 )
@@ -284,15 +269,35 @@ private fun LoadedContent(
                                         maxLines = 3,
                                     )
                                     Spacer(modifier = Modifier.width(4.dp))
-                                    Text(
+                                    Column(
                                         modifier = Modifier
                                             .align(Alignment.Bottom)
-                                            .height(IntrinsicSize.Max)
-                                            .requiredWidthIn(min = 60.dp),
-                                        maxLines = 1,
-                                        text = item.amount,
-                                        textAlign = TextAlign.End,
-                                    )
+                                            .height(IntrinsicSize.Max),
+                                        horizontalAlignment = Alignment.End,
+                                    ) {
+                                        if (item.category.isNotEmpty()) {
+                                            Text(
+                                                modifier = Modifier
+                                                    .background(
+                                                        color = item.categoryColor,
+                                                        shape = RoundedCornerShape(4.dp),
+                                                    )
+                                                    .padding(horizontal = 8.dp, vertical = 2.dp),
+                                                text = item.category,
+                                                maxLines = 1,
+                                                color = Color.White,
+                                                style = MaterialTheme.typography.labelSmall,
+                                            )
+                                            Spacer(modifier = Modifier.height(4.dp))
+                                        }
+                                        Text(
+                                            modifier = Modifier
+                                                .requiredWidthIn(min = 60.dp),
+                                            maxLines = 1,
+                                            text = item.amount,
+                                            textAlign = TextAlign.End,
+                                        )
+                                    }
                                 }
                             }
                             if (showImages && item.imageUrls.isNotEmpty()) {

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
@@ -90,6 +90,7 @@ public data class RootHomeMonthlyScreenUiState(
         val amount: String,
         val date: String,
         val category: String,
+        val categoryColor: Color,
         val imageUrls: ImmutableList<String>,
         val event: ItemEvent,
     )
@@ -255,6 +256,14 @@ private fun LoadedContent(
                             Column(
                                 modifier = Modifier.padding(horizontal = padding),
                             ) {
+                                if (item.category.isNotEmpty()) {
+                                    Text(
+                                        text = item.category,
+                                        maxLines = 1,
+                                        style = MaterialTheme.typography.labelSmall,
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                }
                                 Text(
                                     text = item.date,
                                 )
@@ -264,14 +273,6 @@ private fun LoadedContent(
                                         modifier = Modifier.weight(1f),
                                         text = item.title,
                                         maxLines = 3,
-                                    )
-                                    Text(
-                                        modifier = Modifier
-                                            .align(Alignment.Bottom)
-                                            .height(IntrinsicSize.Max)
-                                            .requiredWidthIn(min = 80.dp),
-                                        text = item.category,
-                                        maxLines = 1,
                                     )
                                     Spacer(modifier = Modifier.width(4.dp))
                                     Text(
@@ -367,6 +368,7 @@ private fun RootHomeMonthlyScreenPreviewContent(isDarkTheme: Boolean) {
                             amount = "¥3,280",
                             date = "2026/02/25",
                             category = "ショッピング",
+                            categoryColor = Color(0xFFE65100),
                             imageUrls = listOf<String>().toImmutableList(),
                             event = noOpItemEvent,
                         ),
@@ -375,6 +377,7 @@ private fun RootHomeMonthlyScreenPreviewContent(isDarkTheme: Boolean) {
                             amount = "¥5,430",
                             date = "2026/02/24",
                             category = "食費",
+                            categoryColor = Color(0xFF558B2F),
                             imageUrls = listOf<String>().toImmutableList(),
                             event = noOpItemEvent,
                         ),
@@ -383,6 +386,7 @@ private fun RootHomeMonthlyScreenPreviewContent(isDarkTheme: Boolean) {
                             amount = "¥8,200",
                             date = "2026/02/20",
                             category = "光熱費",
+                            categoryColor = Color(0xFF1565C0),
                             imageUrls = listOf<String>().toImmutableList(),
                             event = noOpItemEvent,
                         ),

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/home/monthly/RootHomeMonthlyScreen.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.money.frontend.common.ui.screen.root.home.monthly
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +21,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -258,8 +260,15 @@ private fun LoadedContent(
                             ) {
                                 if (item.category.isNotEmpty()) {
                                     Text(
+                                        modifier = Modifier
+                                            .background(
+                                                color = item.categoryColor,
+                                                shape = RoundedCornerShape(4.dp),
+                                            )
+                                            .padding(horizontal = 8.dp, vertical = 2.dp),
                                         text = item.category,
                                         maxLines = 1,
+                                        color = Color.White,
                                         style = MaterialTheme.typography.labelSmall,
                                     )
                                     Spacer(modifier = Modifier.height(4.dp))

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/home/monthly/RootHomeMonthlyScreenViewModel.kt
@@ -195,11 +195,13 @@ public class RootHomeMonthlyScreenViewModel(
         return RootHomeMonthlyScreenUiState.LoadingState.Loaded(
             yearMonth = "${sinceDate.year}年${sinceDate.monthNumber}月",
             items = nodes.map { node ->
+                val categoryName = node.moneyUsageSubCategory?.category?.name.orEmpty()
                 RootHomeMonthlyScreenUiState.Item(
                     title = node.title,
                     amount = "${Formatter.formatMoney(node.amount)}円",
                     date = Formatter.formatDateTime(node.date),
-                    category = node.moneyUsageSubCategory?.name.orEmpty(),
+                    category = categoryName,
+                    categoryColor = reservedColorModel.getColor(categoryName),
                     imageUrls = node.images.map { it.url }.toImmutableList(),
                     event = ItemEventImpl(
                         coroutineScope = viewModelScope,


### PR DESCRIPTION
## 概要
月別画面の支出項目にカテゴリを色付きバッジとして表示するように改善しました。

## 主な変更

- **GraphQLスキーマ更新**: `moneyUsageSubCategory`クエリに親カテゴリ情報を追加
- **UIコンポーネント改善**: 
  - カテゴリ名を色付きバッジ（RoundedCornerShape）として表示
  - 従来のテキスト表示から視覚的にわかりやすいデザインに変更
  - バッジは白テキスト、背景色はカテゴリごとの色を使用
- **ViewModel更新**: 
  - `Item`データクラスに`categoryColor`フィールドを追加
  - 親カテゴリ名を取得し、`reservedColorModel`から対応する色を取得
- **プレビュー更新**: サンプルデータに各カテゴリの色を指定

## 実装の詳細

- カテゴリバッジは`background()`と`RoundedCornerShape(4.dp)`で実装
- 親カテゴリ名（`moneyUsageSubCategory.category.name`）を使用してカテゴリを識別
- 空のカテゴリは表示しない条件分岐を追加

https://claude.ai/code/session_01GVzXm4BsqmNn35pvLrX6oz