### PR TITLE
Fix infinite query loop on imported mail search

### DIFF
--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/mail/ImportedMailListScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/mail/ImportedMailListScreen.kt
@@ -219,10 +219,6 @@ private fun MainContent(
                         item {
                             LaunchedEffect(Unit) {
                                 moreLoading()
-                                while (isActive) {
-                                    delay(500)
-                                    moreLoading()
-                                }
                             }
                             Box(
                                 modifier = Modifier.fillMaxWidth()

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/mail/ImportedMailListScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/mail/ImportedMailListScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import net.matsudamper.money.frontend.common.ui.base.KakeBoTopAppBar
 import net.matsudamper.money.frontend.common.ui.base.LocalScrollToTopHandler

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/mail/ImportedMailListViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/root/mail/ImportedMailListViewModel.kt
@@ -69,6 +69,7 @@ public class ImportedMailListViewModel(
                 override fun refresh() {
                     viewModelStateFlow.update {
                         it.copy(
+                            isLoading = false,
                             mailState = it.mailState.copy(
                                 cursor = null,
                                 finishLoadingToEnd = false,
@@ -163,6 +164,7 @@ public class ImportedMailListViewModel(
         }
         viewModelStateFlow.update {
             it.copy(
+                isLoading = false,
                 mailState = ViewModelState.MailState(
                     query = newQuery,
                 ),
@@ -185,6 +187,7 @@ public class ImportedMailListViewModel(
         }
         viewModelStateFlow.update {
             it.copy(
+                isLoading = false,
                 mailState = ViewModelState.MailState(
                     query = newQuery,
                 ),
@@ -213,6 +216,7 @@ public class ImportedMailListViewModel(
         }
         viewModelStateFlow.update {
             it.copy(
+                isLoading = false,
                 mailState = ViewModelState.MailState(
                     query = newQuery,
                 ),
@@ -244,6 +248,7 @@ public class ImportedMailListViewModel(
     private fun fetch() {
         val mailState = viewModelStateFlow.value.mailState
         if (mailState.finishLoadingToEnd == true) return
+        if (viewModelStateFlow.value.isLoading) return
         fetchJob.cancel()
         viewModelScope.launch(
             Job().also { fetchJob = it },
@@ -293,7 +298,7 @@ public class ImportedMailListViewModel(
     }
 
     private data class ViewModelState(
-        val isLoading: Boolean = true,
+        val isLoading: Boolean = false,
         val mailState: MailState = MailState(),
     ) {
         data class MailState(


### PR DESCRIPTION
Fixes the infinite loop where ImportedMailListScreenMailPaging query was invoked repeatedly during search on the imported mail screen.

---
*PR created automatically by Jules for task [866233936155585864](https://jules.google.com/task/866233936155585864) started by @matsudamper*