### PR TITLE
Fix Paparazzi screenshot generation failure

### DIFF
--- a/frontend/common/ui/src/androidHostTest/kotlin/net/matsudamper/money/frontend/common/ui/screenshot/ScreenshotTest.kt
+++ b/frontend/common/ui/src/androidHostTest/kotlin/net/matsudamper/money/frontend/common/ui/screenshot/ScreenshotTest.kt
@@ -39,6 +39,7 @@ class ScreenshotTest(
     @Test
     fun snapshot() {
         paparazzi.snapshot(name = preview.methodName) {
+            org.jetbrains.compose.resources.PreviewContextConfigurationEffect()
             preview()
         }
     }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/root/settings/CategorySettingScreen.kt
@@ -825,7 +825,6 @@ private fun SubCategoryRow(
 }
 
 @Composable
-@Preview
 private fun CategorySettingScreenPreviewContent(
     heroMode: SettingCategoryScreenUiState.HeroMode = SettingCategoryScreenUiState.HeroMode.Base,
     isAddingSubCategory: Boolean = false,
@@ -894,4 +893,10 @@ private fun CategorySettingScreenPreviewContent(
             windowInsets = PaddingValues(0.dp),
         )
     }
+}
+
+@Composable
+@Preview
+private fun CategorySettingScreenPreview() {
+    CategorySettingScreenPreviewContent()
 }


### PR DESCRIPTION
Fixed Paparazzi screenshot failures caused by uninitialized Android Context in Compose Resources and reflection unboxing NPEs in parameterized @Preview composables.

---
*PR created automatically by Jules for task [11419166828806188765](https://jules.google.com/task/11419166828806188765) started by @matsudamper*