### PR TITLE
起動時warmup失敗時にfail-fastでプロセスを終了する (#888)

### DIFF
--- a/.claude/skills/download-graphql-schema/SKILL.md
+++ b/.claude/skills/download-graphql-schema/SKILL.md
@@ -24,7 +24,7 @@ description: Guide for updating the frontend GraphQL schema by downloading it fr
 ## 前提条件
 
 - `IS_DEBUG=true` が必須：バックエンドの `MoneyGraphQlSchema` はこのフラグが `true` の場合のみイントロスペクションを有効化する
-- `schema_update_local.env` はダミー値でDBへの接続を設定しているが、イントロスペクションに DB 接続は不要なため問題ない
+- `schema_update_local.env` はダミー値でDBへの接続を設定しているが、`CI=true` により warmup をスキップするため、イントロスペクションに DB 接続は不要
 - バックエンドは `PORT=80`（`localhost` のポート80）で起動するため、**ルート権限が必要**
 
 ---
@@ -56,6 +56,7 @@ echo "PID: $BACKEND_PID"
 | `PORT` | `80` | Ktorがリッスンするポート     |
 | `DOMAIN` | `localhost` | CORSホスト設定          |
 | `IS_DEBUG` | `true` | イントロスペクションを有効化（必須） |
+| `CI` | `true` | warmup をスキップ（DB 接続不要） |
 | `DB_*` | ダミー値 | DBには接続しないが変数が必要    |
 
 ### 3. バックエンドの起動を確認する

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,7 @@ jobs:
           mkdir -p backend-server
           tar -xf backend/build/distributions/backend.tar -C backend-server --strip-components=1
           export $(grep -v '^#' schema_update_local.env | xargs)
+          export CI=true
           export PORT=8080
 
           SERVER_LOG=backend-server/server.log

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -41,6 +41,7 @@ jobs:
       - name: ネイティブバイナリの healthz スモークテスト
         run: |
           export $(grep -v '^#' schema_update_local.env | xargs)
+          export CI=true
           export PORT=8080
           export IS_DEBUG=true
           export HTML_PATH=/tmp/html

--- a/backend/src/main/kotlin/net/matsudamper/money/backend/Main.kt
+++ b/backend/src/main/kotlin/net/matsudamper/money/backend/Main.kt
@@ -62,10 +62,8 @@ class Main {
             MoneyGraphQlSchema.graphql
             val diContainer = MainDiContainer()
             if (System.getenv("CI")?.toBooleanStrictOrNull() != true) {
-                runCatching { DbConnectionImpl.warmup() }
-                    .onFailure { TraceLogger.impl().noticeThrowable(it, isError = true) }
-                runCatching { diContainer.warmup() }
-                    .onFailure { TraceLogger.impl().noticeThrowable(it, isError = true) }
+                DbConnectionImpl.warmup()
+                diContainer.warmup()
             }
 
             val engine = embeddedServer(

--- a/schema_update_local.env
+++ b/schema_update_local.env
@@ -1,3 +1,4 @@
+CI=true
 PORT=80
 DOMAIN=localhost
 DB_HOST=localhost


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# なぜやるか

DBやRedisに接続できない状態でもサーバーが起動し、`/healthz` が無条件で `ok` を返すため、ロードバランサから正常とみなされリクエストが流れ込む問題がある（#888）。

# 実装した事

- `DbConnectionImpl.warmup()` と `diContainer.warmup()` の `runCatching` を削除し、warmup 失敗時は例外をそのまま伝播させて起動を中断する
- DB接続不要なスキーマ取得（`schema_update_local.env`）および CI の healthz スモークテストでは `CI=true` により warmup をスキップするよう調整

## テスト

- warmup 失敗（`CI` 未設定・ダミーDB）: プロセスが exit code 1 で終了することを確認
- `CI=true` 設定時: サーバー起動成功、`/healthz` が `ok` を返すことを確認

[failfast_test.log](https://cursor.com/agents/bc-66262aa5-5733-4b43-a001-ce88f4e21a0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffailfast_test.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66262aa5-5733-4b43-a001-ce88f4e21a0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66262aa5-5733-4b43-a001-ce88f4e21a0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 起動時のウォームアップ処理で発生したエラーが適切に通知されるようになりました。
  * CI環境でのヘルスチェック時に不要なウォームアップをスキップし、データベース接続なしで検証できるようになりました。

* **ドキュメント**
  * スキーマ更新手順に、CI環境での設定とウォームアップの扱いを追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->