### PR TITLE
ログイン画面のユーザー名・パスワード入力をHTML埋め込みに変更

### DIFF
--- a/frontend/common/ui/src/androidMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.android.kt
+++ b/frontend/common/ui/src/androidMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.android.kt
@@ -1,0 +1,49 @@
+package net.matsudamper.money.frontend.common.ui.layout
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+
+@Composable
+public actual fun LoginCredentialsFields(
+    username: String,
+    password: String,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    usernameLabel: String,
+    passwordLabel: String,
+    textStyle: TextStyle,
+    modifier: Modifier,
+    enabled: Boolean,
+) {
+    Column(modifier = modifier) {
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            onValueChange = onUsernameChange,
+            text = username,
+            textStyle = textStyle,
+            label = usernameLabel,
+            maxLines = 1,
+            enabled = enabled,
+            autocomplete = "username",
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            onValueChange = onPasswordChange,
+            text = password,
+            textStyle = textStyle,
+            label = passwordLabel,
+            maxLines = 1,
+            type = TextFieldType.Password,
+            enabled = enabled,
+            autocomplete = "current-password",
+        )
+    }
+}

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.kt
@@ -1,0 +1,19 @@
+package net.matsudamper.money.frontend.common.ui.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+public expect fun LoginCredentialsFields(
+    username: String,
+    password: String,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    usernameLabel: String,
+    passwordLabel: String,
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+)

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/login/LoginScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/login/LoginScreen.kt
@@ -60,7 +60,7 @@ public fun LoginScreen(
                     .widthIn(max = 400.dp)
                     .fillMaxWidth(),
             ) {
-                val textFieldTextStyle = MaterialTheme.typography.bodySmall
+                val textFieldTextStyle = MaterialTheme.typography.bodyMedium
                     .merge(
                         TextStyle(
                             fontFamily = rememberCustomFontFamily(),

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/login/LoginScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/login/LoginScreen.kt
@@ -33,8 +33,7 @@ import androidx.compose.ui.unit.dp
 import net.matsudamper.money.frontend.common.ui.AppRoot
 import net.matsudamper.money.frontend.common.ui.generated.resources.Res
 import net.matsudamper.money.frontend.common.ui.generated.resources.ic_settings
-import net.matsudamper.money.frontend.common.ui.layout.TextField
-import net.matsudamper.money.frontend.common.ui.layout.TextFieldType
+import net.matsudamper.money.frontend.common.ui.layout.LoginCredentialsFields
 import net.matsudamper.money.frontend.common.ui.rememberCustomFontFamily
 import org.jetbrains.compose.resources.painterResource
 
@@ -75,25 +74,16 @@ public fun LoginScreen(
                     text = "ログイン",
                 )
                 Spacer(modifier = Modifier.height(16.dp))
-                TextField(
+                LoginCredentialsFields(
                     modifier = Modifier.fillMaxWidth(),
-                    onValueChange = { uiState.listener.onUserIdChanged(it) },
-                    text = uiState.userName.text,
+                    username = uiState.userName.text,
+                    password = uiState.password.text,
+                    onUsernameChange = { uiState.listener.onUserIdChanged(it) },
+                    onPasswordChange = { uiState.listener.onPasswordChanged(it) },
+                    onSubmit = { uiState.listener.onClickLogin() },
+                    usernameLabel = "User Name",
+                    passwordLabel = "Password",
                     textStyle = textFieldTextStyle,
-                    label = "User Name",
-                    maxLines = 1,
-                    autocomplete = "username",
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                TextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    onValueChange = { uiState.listener.onPasswordChanged(it) },
-                    text = uiState.password.text,
-                    textStyle = textFieldTextStyle,
-                    label = "Password",
-                    maxLines = 1,
-                    type = TextFieldType.Password,
-                    autocomplete = "current-password",
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 Button(

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/login/LoginScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/login/LoginScreen.kt
@@ -60,7 +60,7 @@ public fun LoginScreen(
                     .widthIn(max = 400.dp)
                     .fillMaxWidth(),
             ) {
-                val textFieldTextStyle = MaterialTheme.typography.bodyMedium
+                val textFieldTextStyle = MaterialTheme.typography.bodySmall
                     .merge(
                         TextStyle(
                             fontFamily = rememberCustomFontFamily(),

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -1,14 +1,12 @@
 package net.matsudamper.money.frontend.common.ui.layout
 
+import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -16,14 +14,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.SubcomposeLayout
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Constraints
@@ -37,6 +34,10 @@ import org.w3c.dom.events.Event
 
 private val CredentialFieldMinHeight = 56.dp
 private val CredentialFieldHorizontalPadding = 16.dp
+
+private class FocusInteractionHolder {
+    var focus: FocusInteraction.Focus? = null
+}
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -128,12 +129,12 @@ private fun HtmlCredentialField(
 ) {
     val colors = MaterialTheme.colorScheme
     val interactionSource = remember { MutableInteractionSource() }
+    val focusInteractionHolder = remember { FocusInteractionHolder() }
     val visualTransformation = if (isPassword) {
         PasswordVisualTransformation()
     } else {
         VisualTransformation.None
     }
-    val displayText = visualTransformation.filter(AnnotatedString(value)).text
     val textFieldColors = TextFieldDefaults.colors()
 
     SubcomposeLayout(
@@ -170,65 +171,61 @@ private fun HtmlCredentialField(
         val overlayHeight = decorationPlaceable.height
         val overlayWidthDp = overlayWidth.toDp()
         val overlayHeightDp = overlayHeight.toDp()
+        val horizontalPaddingPx = CredentialFieldHorizontalPadding.roundToPx()
+        val fontSizePx = textStyle.fontSize.toPx()
+        val letterSpacingPx = textStyle.letterSpacing.toPx()
 
         val overlayPlaceable = subcompose("overlay") {
-            Box(
+            HtmlElementView(
                 modifier = Modifier
                     .width(overlayWidthDp)
                     .height(overlayHeightDp),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = CredentialFieldHorizontalPadding),
-                    text = displayText,
-                    style = textStyle,
-                    maxLines = 1,
-                )
-                HtmlElementView(
-                    modifier = Modifier.fillMaxSize(),
-                    factory = {
-                        val input = document.createElement("input") as HTMLInputElement
-                        input.id = inputId
-                        input.name = inputName
-                        input.type = inputType
-                        input.autocomplete = autocomplete
-                        input.setAttribute("form", FORM_ID)
-                        input.setAttribute("aria-label", label)
-                        input.required = true
-                        input
-                    },
-                    update = { input ->
-                        input.disabled = !enabled
-                        applyMinimalInputStyle(
-                            input = input,
-                            textStyle = textStyle,
-                            caretColor = colors.onSurface,
-                            horizontalPaddingPx = with(density) {
-                                CredentialFieldHorizontalPadding.roundToPx()
-                            },
-                        )
+                factory = {
+                    val input = document.createElement("input") as HTMLInputElement
+                    input.id = inputId
+                    input.name = inputName
+                    input.type = inputType
+                    input.autocomplete = autocomplete
+                    input.setAttribute("form", FORM_ID)
+                    input.setAttribute("aria-label", label)
+                    input.required = true
+                    input
+                },
+                update = { input ->
+                    input.disabled = !enabled
+                    applyInputStyle(
+                        input = input,
+                        textStyle = textStyle,
+                        textColor = colors.onSurface,
+                        caretColor = colors.onSurface,
+                        horizontalPaddingPx = horizontalPaddingPx,
+                        fontSizePx = fontSizePx,
+                        letterSpacingPx = letterSpacingPx,
+                    )
+                    bindFocusHandlers(
+                        input = input,
+                        interactionSource = interactionSource,
+                        focusInteractionHolder = focusInteractionHolder,
+                    )
 
-                        if (input.value != value) {
-                            input.value = value
-                        }
+                    if (input.value != value) {
+                        input.value = value
+                    }
 
-                        input.oninput = { event ->
-                            val newValue = readInputValue(event)
-                            if (newValue != value) {
-                                onValueChange(newValue)
-                            }
+                    input.oninput = { event ->
+                        val newValue = readInputValue(event)
+                        if (newValue != value) {
+                            onValueChange(newValue)
                         }
-                        input.onchange = { event ->
-                            val newValue = readInputValue(event)
-                            if (newValue != value) {
-                                onValueChange(newValue)
-                            }
+                    }
+                    input.onchange = { event ->
+                        val newValue = readInputValue(event)
+                        if (newValue != value) {
+                            onValueChange(newValue)
                         }
-                    },
-                )
-            }
+                    }
+                },
+            )
         }.map { measurable ->
             measurable.measure(
                 Constraints.fixed(
@@ -245,34 +242,78 @@ private fun HtmlCredentialField(
     }
 }
 
-private fun applyMinimalInputStyle(
+private fun bindFocusHandlers(
+    input: HTMLInputElement,
+    interactionSource: MutableInteractionSource,
+    focusInteractionHolder: FocusInteractionHolder,
+) {
+    input.onfocus = {
+        if (focusInteractionHolder.focus == null) {
+            val focus = FocusInteraction.Focus()
+            focusInteractionHolder.focus = focus
+            interactionSource.tryEmit(focus)
+        }
+    }
+    input.onblur = {
+        val focus = focusInteractionHolder.focus
+        if (focus != null) {
+            interactionSource.tryEmit(FocusInteraction.Unfocus(focus))
+            focusInteractionHolder.focus = null
+        }
+    }
+}
+
+private fun applyInputStyle(
     input: HTMLInputElement,
     textStyle: TextStyle,
+    textColor: Color,
     caretColor: Color,
     horizontalPaddingPx: Int,
+    fontSizePx: Float,
+    letterSpacingPx: Float,
 ) {
     val clientHeight = input.clientHeight
+    val verticalPaddingPx = if (clientHeight > 0) {
+        ((clientHeight - fontSizePx) / 2f).coerceAtLeast(0f)
+    } else {
+        0f
+    }
     input.style.apply {
         boxSizing = "border-box"
         width = "100%"
         height = "100%"
         margin = "0"
-        padding = "0 ${horizontalPaddingPx}px"
+        paddingTop = "${verticalPaddingPx}px"
+        paddingBottom = "${verticalPaddingPx}px"
+        paddingLeft = "${horizontalPaddingPx}px"
+        paddingRight = "${horizontalPaddingPx}px"
         border = "none"
         outline = "none"
         backgroundColor = "transparent"
-        color = "transparent"
+        color = textColor.toCssColor()
         setProperty("appearance", "none")
         setProperty("-webkit-appearance", "none")
         setProperty("caret-color", caretColor.toCssColor())
-        fontSize = "${textStyle.fontSize.value}px"
+        fontSize = "${fontSizePx}px"
         fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
-        if (clientHeight > 0) {
-            lineHeight = "${clientHeight}px"
-        } else {
-            lineHeight = textStyle.lineHeight.toString()
-        }
-        setProperty("-webkit-text-fill-color", "transparent")
+        lineHeight = "${fontSizePx}px"
+        letterSpacing = "${letterSpacingPx}px"
+        fontWeight = textStyle.fontWeight?.toCssFontWeight() ?: "normal"
+    }
+}
+
+private fun FontWeight.toCssFontWeight(): String {
+    return when (this) {
+        FontWeight.W100 -> "100"
+        FontWeight.W200 -> "200"
+        FontWeight.W300 -> "300"
+        FontWeight.W400, FontWeight.Normal -> "400"
+        FontWeight.W500, FontWeight.Medium -> "500"
+        FontWeight.W600, FontWeight.SemiBold -> "600"
+        FontWeight.W700, FontWeight.Bold -> "700"
+        FontWeight.W800 -> "800"
+        FontWeight.W900 -> "900"
+        else -> "400"
     }
 }
 

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -2,6 +2,7 @@ package net.matsudamper.money.frontend.common.ui.layout
 
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -27,6 +28,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.HtmlElementView
+import kotlin.math.roundToInt
 import kotlinx.browser.document
 import androidx.compose.material3.TextFieldDefaults as MaterialTextFieldDefaults
 import org.w3c.dom.HTMLFormElement
@@ -35,6 +37,7 @@ import org.w3c.dom.events.Event
 
 private val CredentialFieldMinHeight = 56.dp
 private val CredentialFieldHorizontalPadding = 16.dp
+private val CredentialFieldHintTopGap = 16.dp
 
 private class FocusInteractionHolder {
     var focus: FocusInteraction.Focus? = null
@@ -141,6 +144,8 @@ private fun HtmlCredentialField(
         start = CredentialFieldHorizontalPadding,
         end = CredentialFieldHorizontalPadding,
     )
+    val focused by interactionSource.collectIsFocusedAsState()
+    val labelExpanded = focused || value.isNotEmpty()
 
     SubcomposeLayout(
         modifier = Modifier
@@ -183,9 +188,12 @@ private fun HtmlCredentialField(
         val overlayHeight = decorationPlaceable.height
         val overlayWidthDp = overlayWidth.toDp()
         val overlayHeightDp = overlayHeight.toDp()
-        val verticalPaddingPx = calculateVerticalPaddingPx(
+        val hintTopGapPx = CredentialFieldHintTopGap.roundToPx()
+        val inputVerticalPaddingPx = calculateInputVerticalPaddingPx(
             fieldHeightPx = overlayHeight,
             fontSizePx = fontSizePx,
+            labelExpanded = labelExpanded,
+            hintTopGapPx = hintTopGapPx,
         )
 
         val overlayPlaceable = subcompose("overlay") {
@@ -212,8 +220,8 @@ private fun HtmlCredentialField(
                         textColor = colors.onSurface,
                         caretColor = colors.onSurface,
                         horizontalPaddingPx = horizontalPaddingPx,
-                        topPaddingPx = verticalPaddingPx,
-                        bottomPaddingPx = verticalPaddingPx,
+                        topPaddingPx = inputVerticalPaddingPx.first,
+                        bottomPaddingPx = inputVerticalPaddingPx.second,
                         fontSizePx = fontSizePx,
                         letterSpacingPx = letterSpacingPx,
                     )
@@ -222,20 +230,20 @@ private fun HtmlCredentialField(
                         interactionSource = interactionSource,
                         focusInteractionHolder = focusInteractionHolder,
                         onFocusStyle = {
+                            val focusedPaddingPx = calculateInputVerticalPaddingPx(
+                                fieldHeightPx = overlayHeight,
+                                fontSizePx = fontSizePx,
+                                labelExpanded = true,
+                                hintTopGapPx = hintTopGapPx,
+                            )
                             applyInputStyle(
                                 input = input,
                                 textStyle = textStyle,
                                 textColor = colors.onSurface,
                                 caretColor = colors.onSurface,
                                 horizontalPaddingPx = horizontalPaddingPx,
-                                topPaddingPx = calculateVerticalPaddingPx(
-                                    fieldHeightPx = overlayHeight,
-                                    fontSizePx = fontSizePx,
-                                ),
-                                bottomPaddingPx = calculateVerticalPaddingPx(
-                                    fieldHeightPx = overlayHeight,
-                                    fontSizePx = fontSizePx,
-                                ),
+                                topPaddingPx = focusedPaddingPx.first,
+                                bottomPaddingPx = focusedPaddingPx.second,
                                 fontSizePx = fontSizePx,
                                 letterSpacingPx = letterSpacingPx,
                             )
@@ -274,6 +282,26 @@ private fun HtmlCredentialField(
             overlayPlaceable.placeRelative(0, 0)
         }
     }
+}
+
+private fun calculateInputVerticalPaddingPx(
+    fieldHeightPx: Int,
+    fontSizePx: Float,
+    labelExpanded: Boolean,
+    hintTopGapPx: Int,
+): Pair<Int, Int> {
+    if (labelExpanded) {
+        val textHeightPx = (fontSizePx * 1.15f).roundToInt()
+        val bottomPaddingPx = hintTopGapPx
+        val topPaddingPx = (fieldHeightPx - textHeightPx - bottomPaddingPx)
+            .coerceAtLeast(hintTopGapPx)
+        return topPaddingPx to bottomPaddingPx
+    }
+    val verticalPaddingPx = calculateVerticalPaddingPx(
+        fieldHeightPx = fieldHeightPx,
+        fontSizePx = fontSizePx,
+    )
+    return verticalPaddingPx to verticalPaddingPx
 }
 
 private fun calculateVerticalPaddingPx(
@@ -335,7 +363,7 @@ private fun applyInputStyle(
         setProperty("caret-color", caretColor.toCssColor())
         fontSize = "${fontSizePx}px"
         fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
-        lineHeight = "${fontSizePx}px"
+        lineHeight = "${(fontSizePx * 1.15f).roundToInt()}px"
         if (letterSpacingPx != 0f) {
             letterSpacing = "${letterSpacingPx}px"
         } else {

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -2,7 +2,6 @@ package net.matsudamper.money.frontend.common.ui.layout
 
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -36,8 +35,6 @@ import org.w3c.dom.events.Event
 
 private val CredentialFieldMinHeight = 56.dp
 private val CredentialFieldHorizontalPadding = 16.dp
-private val CredentialFieldExpandedVerticalPadding = 24.dp
-private val CredentialFieldCollapsedVerticalPadding = 16.dp
 
 private class FocusInteractionHolder {
     var focus: FocusInteraction.Focus? = null
@@ -140,26 +137,19 @@ private fun HtmlCredentialField(
         VisualTransformation.None
     }
     val textFieldColors = TextFieldDefaults.colors()
-    val focused by interactionSource.collectIsFocusedAsState()
-    val labelExpanded = focused || value.isNotEmpty()
+    val contentPadding = MaterialTextFieldDefaults.contentPaddingWithLabel(
+        start = CredentialFieldHorizontalPadding,
+        end = CredentialFieldHorizontalPadding,
+    )
 
     SubcomposeLayout(
         modifier = Modifier
             .fillMaxWidth()
             .defaultMinSize(minHeight = CredentialFieldMinHeight),
     ) { constraints ->
-        val expandedVerticalPaddingPx = CredentialFieldExpandedVerticalPadding.roundToPx()
-        val topPaddingPx = if (labelExpanded) {
-            expandedVerticalPaddingPx
-        } else {
-            CredentialFieldCollapsedVerticalPadding.roundToPx()
-        }
-        val bottomPaddingPx = if (labelExpanded) {
-            expandedVerticalPaddingPx
-        } else {
-            CredentialFieldCollapsedVerticalPadding.roundToPx()
-        }
-        val horizontalPaddingPx = CredentialFieldHorizontalPadding.roundToPx()
+        val horizontalPaddingPx = contentPadding
+            .calculateLeftPadding(layoutDirection)
+            .roundToPx()
         val fontSizePx = textStyle.fontSize.toPx()
         val letterSpacingPx = textStyle.letterSpacing.toPx()
 
@@ -183,6 +173,7 @@ private fun HtmlCredentialField(
                 isError = false,
                 interactionSource = interactionSource,
                 colors = textFieldColors,
+                contentPadding = contentPadding,
             )
         }.map { measurable ->
             measurable.measure(constraints)
@@ -192,6 +183,10 @@ private fun HtmlCredentialField(
         val overlayHeight = decorationPlaceable.height
         val overlayWidthDp = overlayWidth.toDp()
         val overlayHeightDp = overlayHeight.toDp()
+        val verticalPaddingPx = calculateVerticalPaddingPx(
+            fieldHeightPx = overlayHeight,
+            fontSizePx = fontSizePx,
+        )
 
         val overlayPlaceable = subcompose("overlay") {
             HtmlElementView(
@@ -217,8 +212,8 @@ private fun HtmlCredentialField(
                         textColor = colors.onSurface,
                         caretColor = colors.onSurface,
                         horizontalPaddingPx = horizontalPaddingPx,
-                        topPaddingPx = topPaddingPx,
-                        bottomPaddingPx = bottomPaddingPx,
+                        topPaddingPx = verticalPaddingPx,
+                        bottomPaddingPx = verticalPaddingPx,
                         fontSizePx = fontSizePx,
                         letterSpacingPx = letterSpacingPx,
                     )
@@ -233,8 +228,14 @@ private fun HtmlCredentialField(
                                 textColor = colors.onSurface,
                                 caretColor = colors.onSurface,
                                 horizontalPaddingPx = horizontalPaddingPx,
-                                topPaddingPx = expandedVerticalPaddingPx,
-                                bottomPaddingPx = expandedVerticalPaddingPx,
+                                topPaddingPx = calculateVerticalPaddingPx(
+                                    fieldHeightPx = overlayHeight,
+                                    fontSizePx = fontSizePx,
+                                ),
+                                bottomPaddingPx = calculateVerticalPaddingPx(
+                                    fieldHeightPx = overlayHeight,
+                                    fontSizePx = fontSizePx,
+                                ),
                                 fontSizePx = fontSizePx,
                                 letterSpacingPx = letterSpacingPx,
                             )
@@ -273,6 +274,13 @@ private fun HtmlCredentialField(
             overlayPlaceable.placeRelative(0, 0)
         }
     }
+}
+
+private fun calculateVerticalPaddingPx(
+    fieldHeightPx: Int,
+    fontSizePx: Float,
+): Int {
+    return ((fieldHeightPx - fontSizePx) / 2f).toInt().coerceAtLeast(0)
 }
 
 private fun bindFocusHandlers(
@@ -328,7 +336,11 @@ private fun applyInputStyle(
         fontSize = "${fontSizePx}px"
         fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
         lineHeight = "${fontSizePx}px"
-        letterSpacing = "${letterSpacingPx}px"
+        if (letterSpacingPx != 0f) {
+            letterSpacing = "${letterSpacingPx}px"
+        } else {
+            letterSpacing = "0"
+        }
         fontWeight = textStyle.fontWeight?.toCssFontWeight() ?: "normal"
     }
 }

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -4,8 +4,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,10 +21,12 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.HtmlElementView
 import kotlinx.browser.document
@@ -28,6 +34,9 @@ import androidx.compose.material3.TextFieldDefaults as MaterialTextFieldDefaults
 import org.w3c.dom.HTMLFormElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
+
+private val CredentialFieldMinHeight = 56.dp
+private val CredentialFieldHorizontalPadding = 16.dp
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -125,28 +134,60 @@ private fun HtmlCredentialField(
         VisualTransformation.None
     }
     val displayText = visualTransformation.filter(AnnotatedString(value)).text
-    val inputMinHeight = remember(textStyle) {
-        (textStyle.fontSize.value + 8).dp
-    }
+    val textFieldColors = TextFieldDefaults.colors()
 
-    MaterialTextFieldDefaults.DecorationBox(
-        value = value,
-        visualTransformation = visualTransformation,
-        innerTextField = {
+    SubcomposeLayout(
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = CredentialFieldMinHeight),
+    ) { constraints ->
+        val decorationPlaceable = subcompose("decoration") {
+            MaterialTextFieldDefaults.DecorationBox(
+                value = value,
+                visualTransformation = visualTransformation,
+                innerTextField = {},
+                label = {
+                    Text(label)
+                },
+                placeholder = null,
+                leadingIcon = null,
+                trailingIcon = null,
+                prefix = null,
+                suffix = null,
+                supportingText = null,
+                shape = MaterialTextFieldDefaults.shape,
+                singleLine = true,
+                enabled = enabled,
+                isError = false,
+                interactionSource = interactionSource,
+                colors = textFieldColors,
+            )
+        }.map { measurable ->
+            measurable.measure(constraints)
+        }.first()
+
+        val overlayWidth = decorationPlaceable.width
+        val overlayHeight = decorationPlaceable.height
+        val overlayWidthDp = overlayWidth.toDp()
+        val overlayHeightDp = overlayHeight.toDp()
+
+        val overlayPlaceable = subcompose("overlay") {
             Box(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .width(overlayWidthDp)
+                    .height(overlayHeightDp),
                 contentAlignment = Alignment.CenterStart,
             ) {
                 Text(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = CredentialFieldHorizontalPadding),
                     text = displayText,
                     style = textStyle,
                     maxLines = 1,
                 )
                 HtmlElementView(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(inputMinHeight),
+                    modifier = Modifier.fillMaxSize(),
                     factory = {
                         val input = document.createElement("input") as HTMLInputElement
                         input.id = inputId
@@ -164,6 +205,9 @@ private fun HtmlCredentialField(
                             input = input,
                             textStyle = textStyle,
                             caretColor = colors.onSurface,
+                            horizontalPaddingPx = with(density) {
+                                CredentialFieldHorizontalPadding.roundToPx()
+                            },
                         )
 
                         if (input.value != value) {
@@ -185,36 +229,35 @@ private fun HtmlCredentialField(
                     },
                 )
             }
-        },
-        label = {
-            Text(label)
-        },
-        placeholder = null,
-        leadingIcon = null,
-        trailingIcon = null,
-        prefix = null,
-        suffix = null,
-        supportingText = null,
-        shape = MaterialTextFieldDefaults.shape,
-        singleLine = true,
-        enabled = enabled,
-        isError = false,
-        interactionSource = interactionSource,
-        colors = TextFieldDefaults.colors(),
-    )
+        }.map { measurable ->
+            measurable.measure(
+                Constraints.fixed(
+                    width = overlayWidth,
+                    height = overlayHeight,
+                ),
+            )
+        }.first()
+
+        layout(overlayWidth, overlayHeight) {
+            decorationPlaceable.placeRelative(0, 0)
+            overlayPlaceable.placeRelative(0, 0)
+        }
+    }
 }
 
 private fun applyMinimalInputStyle(
     input: HTMLInputElement,
     textStyle: TextStyle,
     caretColor: Color,
+    horizontalPaddingPx: Int,
 ) {
+    val clientHeight = input.clientHeight
     input.style.apply {
         boxSizing = "border-box"
         width = "100%"
         height = "100%"
         margin = "0"
-        padding = "0"
+        padding = "0 ${horizontalPaddingPx}px"
         border = "none"
         outline = "none"
         backgroundColor = "transparent"
@@ -224,7 +267,11 @@ private fun applyMinimalInputStyle(
         setProperty("caret-color", caretColor.toCssColor())
         fontSize = "${textStyle.fontSize.value}px"
         fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
-        lineHeight = textStyle.lineHeight.toString()
+        if (clientHeight > 0) {
+            lineHeight = "${clientHeight}px"
+        } else {
+            lineHeight = textStyle.lineHeight.toString()
+        }
         setProperty("-webkit-text-fill-color", "transparent")
     }
 }

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -36,8 +36,7 @@ import org.w3c.dom.events.Event
 
 private val CredentialFieldMinHeight = 56.dp
 private val CredentialFieldHorizontalPadding = 16.dp
-private val CredentialFieldExpandedTopPadding = 24.dp
-private val CredentialFieldExpandedBottomPadding = 8.dp
+private val CredentialFieldExpandedVerticalPadding = 24.dp
 private val CredentialFieldCollapsedVerticalPadding = 16.dp
 
 private class FocusInteractionHolder {
@@ -149,15 +148,14 @@ private fun HtmlCredentialField(
             .fillMaxWidth()
             .defaultMinSize(minHeight = CredentialFieldMinHeight),
     ) { constraints ->
-        val expandedTopPaddingPx = CredentialFieldExpandedTopPadding.roundToPx()
-        val expandedBottomPaddingPx = CredentialFieldExpandedBottomPadding.roundToPx()
+        val expandedVerticalPaddingPx = CredentialFieldExpandedVerticalPadding.roundToPx()
         val topPaddingPx = if (labelExpanded) {
-            expandedTopPaddingPx
+            expandedVerticalPaddingPx
         } else {
             CredentialFieldCollapsedVerticalPadding.roundToPx()
         }
         val bottomPaddingPx = if (labelExpanded) {
-            expandedBottomPaddingPx
+            expandedVerticalPaddingPx
         } else {
             CredentialFieldCollapsedVerticalPadding.roundToPx()
         }
@@ -235,8 +233,8 @@ private fun HtmlCredentialField(
                                 textColor = colors.onSurface,
                                 caretColor = colors.onSurface,
                                 horizontalPaddingPx = horizontalPaddingPx,
-                                topPaddingPx = expandedTopPaddingPx,
-                                bottomPaddingPx = expandedBottomPaddingPx,
+                                topPaddingPx = expandedVerticalPaddingPx,
+                                bottomPaddingPx = expandedVerticalPaddingPx,
                                 fontSizePx = fontSizePx,
                                 letterSpacingPx = letterSpacingPx,
                             )

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -1,43 +1,34 @@
 package net.matsudamper.money.frontend.common.ui.layout
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.HtmlElementView
-import kotlin.math.roundToInt
 import kotlinx.browser.document
 import androidx.compose.material3.TextFieldDefaults as MaterialTextFieldDefaults
 import org.w3c.dom.HTMLFormElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
 
-private val CredentialFieldMinHeight = 56.dp
-private val CredentialFieldHorizontalPadding = 16.dp
-private val CredentialFieldHintTopGap = 16.dp
+private val InputLineHeight = 24.dp
 
 private class FocusInteractionHolder {
     var focus: FocusInteraction.Focus? = null
@@ -72,7 +63,6 @@ public actual fun LoginCredentialsFields(
             autocomplete = "username",
             textStyle = textStyle,
             enabled = enabled,
-            isPassword = false,
         )
         Spacer(modifier = Modifier.height(8.dp))
         HtmlCredentialField(
@@ -85,7 +75,6 @@ public actual fun LoginCredentialsFields(
             autocomplete = "current-password",
             textStyle = textStyle,
             enabled = enabled,
-            isPassword = true,
         )
     }
 }
@@ -129,193 +118,95 @@ private fun HtmlCredentialField(
     autocomplete: String,
     textStyle: TextStyle,
     enabled: Boolean,
-    isPassword: Boolean,
 ) {
     val colors = MaterialTheme.colorScheme
     val interactionSource = remember { MutableInteractionSource() }
     val focusInteractionHolder = remember { FocusInteractionHolder() }
-    val visualTransformation = if (isPassword) {
-        PasswordVisualTransformation()
-    } else {
-        VisualTransformation.None
-    }
-    val textFieldColors = TextFieldDefaults.colors()
-    val contentPadding = MaterialTextFieldDefaults.contentPaddingWithLabel(
-        start = CredentialFieldHorizontalPadding,
-        end = CredentialFieldHorizontalPadding,
-    )
-    val focused by interactionSource.collectIsFocusedAsState()
-    val labelExpanded = focused || value.isNotEmpty()
+    val clickInteractionSource = remember { MutableInteractionSource() }
 
-    SubcomposeLayout(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .defaultMinSize(minHeight = CredentialFieldMinHeight),
-    ) { constraints ->
-        val horizontalPaddingPx = contentPadding
-            .calculateLeftPadding(layoutDirection)
-            .roundToPx()
-        val fontSizePx = textStyle.fontSize.toPx()
-        val letterSpacingPx = textStyle.letterSpacing.toPx()
-
-        val decorationPlaceable = subcompose("decoration") {
-            MaterialTextFieldDefaults.DecorationBox(
-                value = value,
-                visualTransformation = visualTransformation,
-                innerTextField = {},
-                label = {
-                    Text(label)
-                },
-                placeholder = null,
-                leadingIcon = null,
-                trailingIcon = null,
-                prefix = null,
-                suffix = null,
-                supportingText = null,
-                shape = MaterialTextFieldDefaults.shape,
-                singleLine = true,
+            .clickable(
+                interactionSource = clickInteractionSource,
+                indication = null,
                 enabled = enabled,
-                isError = false,
-                interactionSource = interactionSource,
-                colors = textFieldColors,
-                contentPadding = contentPadding,
-            )
-        }.map { measurable ->
-            measurable.measure(constraints)
-        }.first()
-
-        val overlayWidth = decorationPlaceable.width
-        val overlayHeight = decorationPlaceable.height
-        val overlayWidthDp = overlayWidth.toDp()
-        val overlayHeightDp = overlayHeight.toDp()
-        val hintTopGapPx = CredentialFieldHintTopGap.roundToPx()
-        val inputVerticalPaddingPx = calculateInputVerticalPaddingPx(
-            fieldHeightPx = overlayHeight,
-            fontSizePx = fontSizePx,
-            labelExpanded = labelExpanded,
-            hintTopGapPx = hintTopGapPx,
+            ) {
+                (document.getElementById(inputId) as? HTMLInputElement)?.focus()
+            },
+    ) {
+        MaterialTextFieldDefaults.DecorationBox(
+            value = value,
+            visualTransformation = VisualTransformation.None,
+            innerTextField = {
+                HtmlElementView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(InputLineHeight),
+                    factory = {
+                        val input = document.createElement("input") as HTMLInputElement
+                        input.id = inputId
+                        input.name = inputName
+                        input.type = inputType
+                        input.autocomplete = autocomplete
+                        input.setAttribute("form", FORM_ID)
+                        input.setAttribute("aria-label", label)
+                        input.required = true
+                        input
+                    },
+                    update = { input ->
+                        input.disabled = !enabled
+                        applyInputStyle(
+                            input = input,
+                            fontSizeSp = textStyle.fontSize.value,
+                            textColor = colors.onSurface,
+                        )
+                        bindFocusHandlers(
+                            input = input,
+                            interactionSource = interactionSource,
+                            focusInteractionHolder = focusInteractionHolder,
+                        )
+                        if (input.value != value) {
+                            input.value = value
+                        }
+                        input.oninput = { event ->
+                            val newValue = readInputValue(event)
+                            if (newValue != value) {
+                                onValueChange(newValue)
+                            }
+                        }
+                        input.onchange = { event ->
+                            val newValue = readInputValue(event)
+                            if (newValue != value) {
+                                onValueChange(newValue)
+                            }
+                        }
+                    },
+                )
+            },
+            label = {
+                Text(label)
+            },
+            placeholder = null,
+            leadingIcon = null,
+            trailingIcon = null,
+            prefix = null,
+            suffix = null,
+            supportingText = null,
+            shape = MaterialTextFieldDefaults.shape,
+            singleLine = true,
+            enabled = enabled,
+            isError = false,
+            interactionSource = interactionSource,
+            colors = TextFieldDefaults.colors(),
         )
-
-        val overlayPlaceable = subcompose("overlay") {
-            HtmlElementView(
-                modifier = Modifier
-                    .width(overlayWidthDp)
-                    .height(overlayHeightDp),
-                factory = {
-                    val input = document.createElement("input") as HTMLInputElement
-                    input.id = inputId
-                    input.name = inputName
-                    input.type = inputType
-                    input.autocomplete = autocomplete
-                    input.setAttribute("form", FORM_ID)
-                    input.setAttribute("aria-label", label)
-                    input.required = true
-                    input
-                },
-                update = { input ->
-                    input.disabled = !enabled
-                    applyInputStyle(
-                        input = input,
-                        textStyle = textStyle,
-                        textColor = colors.onSurface,
-                        caretColor = colors.onSurface,
-                        horizontalPaddingPx = horizontalPaddingPx,
-                        topPaddingPx = inputVerticalPaddingPx.first,
-                        bottomPaddingPx = inputVerticalPaddingPx.second,
-                        fontSizePx = fontSizePx,
-                        letterSpacingPx = letterSpacingPx,
-                    )
-                    bindFocusHandlers(
-                        input = input,
-                        interactionSource = interactionSource,
-                        focusInteractionHolder = focusInteractionHolder,
-                        onFocusStyle = {
-                            val focusedPaddingPx = calculateInputVerticalPaddingPx(
-                                fieldHeightPx = overlayHeight,
-                                fontSizePx = fontSizePx,
-                                labelExpanded = true,
-                                hintTopGapPx = hintTopGapPx,
-                            )
-                            applyInputStyle(
-                                input = input,
-                                textStyle = textStyle,
-                                textColor = colors.onSurface,
-                                caretColor = colors.onSurface,
-                                horizontalPaddingPx = horizontalPaddingPx,
-                                topPaddingPx = focusedPaddingPx.first,
-                                bottomPaddingPx = focusedPaddingPx.second,
-                                fontSizePx = fontSizePx,
-                                letterSpacingPx = letterSpacingPx,
-                            )
-                        },
-                    )
-
-                    if (input.value != value) {
-                        input.value = value
-                    }
-
-                    input.oninput = { event ->
-                        val newValue = readInputValue(event)
-                        if (newValue != value) {
-                            onValueChange(newValue)
-                        }
-                    }
-                    input.onchange = { event ->
-                        val newValue = readInputValue(event)
-                        if (newValue != value) {
-                            onValueChange(newValue)
-                        }
-                    }
-                },
-            )
-        }.map { measurable ->
-            measurable.measure(
-                Constraints.fixed(
-                    width = overlayWidth,
-                    height = overlayHeight,
-                ),
-            )
-        }.first()
-
-        layout(overlayWidth, overlayHeight) {
-            decorationPlaceable.placeRelative(0, 0)
-            overlayPlaceable.placeRelative(0, 0)
-        }
     }
-}
-
-private fun calculateInputVerticalPaddingPx(
-    fieldHeightPx: Int,
-    fontSizePx: Float,
-    labelExpanded: Boolean,
-    hintTopGapPx: Int,
-): Pair<Int, Int> {
-    if (labelExpanded) {
-        val textHeightPx = (fontSizePx * 1.15f).roundToInt()
-        val bottomPaddingPx = hintTopGapPx
-        val topPaddingPx = (fieldHeightPx - textHeightPx - bottomPaddingPx)
-            .coerceAtLeast(hintTopGapPx)
-        return topPaddingPx to bottomPaddingPx
-    }
-    val verticalPaddingPx = calculateVerticalPaddingPx(
-        fieldHeightPx = fieldHeightPx,
-        fontSizePx = fontSizePx,
-    )
-    return verticalPaddingPx to verticalPaddingPx
-}
-
-private fun calculateVerticalPaddingPx(
-    fieldHeightPx: Int,
-    fontSizePx: Float,
-): Int {
-    return ((fieldHeightPx - fontSizePx) / 2f).toInt().coerceAtLeast(0)
 }
 
 private fun bindFocusHandlers(
     input: HTMLInputElement,
     interactionSource: MutableInteractionSource,
     focusInteractionHolder: FocusInteractionHolder,
-    onFocusStyle: () -> Unit,
 ) {
     input.onfocus = {
         if (focusInteractionHolder.focus == null) {
@@ -323,7 +214,6 @@ private fun bindFocusHandlers(
             focusInteractionHolder.focus = focus
             interactionSource.tryEmit(focus)
         }
-        onFocusStyle()
     }
     input.onblur = {
         val focus = focusInteractionHolder.focus
@@ -336,55 +226,26 @@ private fun bindFocusHandlers(
 
 private fun applyInputStyle(
     input: HTMLInputElement,
-    textStyle: TextStyle,
+    fontSizeSp: Float,
     textColor: Color,
-    caretColor: Color,
-    horizontalPaddingPx: Int,
-    topPaddingPx: Int,
-    bottomPaddingPx: Int,
-    fontSizePx: Float,
-    letterSpacingPx: Float,
 ) {
     input.style.apply {
         boxSizing = "border-box"
+        display = "block"
         width = "100%"
         height = "100%"
         margin = "0"
-        paddingTop = "${topPaddingPx}px"
-        paddingBottom = "${bottomPaddingPx}px"
-        paddingLeft = "${horizontalPaddingPx}px"
-        paddingRight = "${horizontalPaddingPx}px"
+        padding = "0"
         border = "none"
         outline = "none"
         backgroundColor = "transparent"
         color = textColor.toCssColor()
         setProperty("appearance", "none")
         setProperty("-webkit-appearance", "none")
-        setProperty("caret-color", caretColor.toCssColor())
-        fontSize = "${fontSizePx}px"
-        fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
-        lineHeight = "${(fontSizePx * 1.15f).roundToInt()}px"
-        if (letterSpacingPx != 0f) {
-            letterSpacing = "${letterSpacingPx}px"
-        } else {
-            letterSpacing = "0"
-        }
-        fontWeight = textStyle.fontWeight?.toCssFontWeight() ?: "normal"
-    }
-}
-
-private fun FontWeight.toCssFontWeight(): String {
-    return when (this) {
-        FontWeight.W100 -> "100"
-        FontWeight.W200 -> "200"
-        FontWeight.W300 -> "300"
-        FontWeight.W400, FontWeight.Normal -> "400"
-        FontWeight.W500, FontWeight.Medium -> "500"
-        FontWeight.W600, FontWeight.SemiBold -> "600"
-        FontWeight.W700, FontWeight.Bold -> "700"
-        FontWeight.W800 -> "800"
-        FontWeight.W900 -> "900"
-        else -> "400"
+        fontSize = "${fontSizeSp}px"
+        lineHeight = "normal"
+        fontFamily = "inherit"
+        letterSpacing = "normal"
     }
 }
 

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -27,7 +27,6 @@ import kotlinx.browser.document
 import androidx.compose.material3.TextFieldDefaults as MaterialTextFieldDefaults
 import org.w3c.dom.HTMLFormElement
 import org.w3c.dom.HTMLInputElement
-import org.w3c.dom.HTMLLabelElement
 import org.w3c.dom.events.Event
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
@@ -44,11 +43,11 @@ public actual fun LoginCredentialsFields(
     modifier: Modifier,
     enabled: Boolean,
 ) {
+    HiddenLoginForm(
+        onSubmit = onSubmit,
+        enabled = enabled,
+    )
     Column(modifier = modifier) {
-        HiddenLoginForm(
-            onSubmit = onSubmit,
-            enabled = enabled,
-        )
         HtmlCredentialField(
             label = usernameLabel,
             value = username,
@@ -77,37 +76,31 @@ public actual fun LoginCredentialsFields(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun HiddenLoginForm(
     onSubmit: () -> Unit,
     enabled: Boolean,
 ) {
-    HtmlElementView(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(0.dp),
-        factory = {
-            val form = document.createElement("form") as HTMLFormElement
-            form.id = FORM_ID
-            form.setAttribute("autocomplete", "on")
-            form.style.apply {
-                display = "none"
-                margin = "0"
-                padding = "0"
-                border = "none"
+    DisposableEffect(enabled) {
+        val form = document.getElementById(FORM_ID) as HTMLFormElement?
+            ?: run {
+                val created = document.createElement("form") as HTMLFormElement
+                created.id = FORM_ID
+                created.setAttribute("autocomplete", "on")
+                created.style.display = "none"
+                document.body?.appendChild(created)
+                created
             }
-            form
-        },
-        update = { form ->
-            form.onsubmit = { event ->
-                event.preventDefault()
-                if (enabled) {
-                    onSubmit()
-                }
+        form.onsubmit = { event ->
+            event.preventDefault()
+            if (enabled) {
+                onSubmit()
             }
-        },
-    )
+        }
+        onDispose {
+            form.onsubmit = null
+        }
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
@@ -132,110 +125,83 @@ private fun HtmlCredentialField(
         VisualTransformation.None
     }
     val displayText = visualTransformation.filter(AnnotatedString(value)).text
+    val inputMinHeight = remember(textStyle) {
+        (textStyle.fontSize.value + 8).dp
+    }
 
-    Box(
-        modifier = Modifier.fillMaxWidth(),
-        contentAlignment = Alignment.CenterStart,
-    ) {
-        MaterialTextFieldDefaults.DecorationBox(
-            value = value,
-            visualTransformation = visualTransformation,
-            innerTextField = {
+    MaterialTextFieldDefaults.DecorationBox(
+        value = value,
+        visualTransformation = visualTransformation,
+        innerTextField = {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = displayText,
                     style = textStyle,
                     maxLines = 1,
                 )
-            },
-            label = {
-                Text(label)
-            },
-            placeholder = null,
-            leadingIcon = null,
-            trailingIcon = null,
-            prefix = null,
-            suffix = null,
-            supportingText = null,
-            shape = MaterialTextFieldDefaults.shape,
-            singleLine = true,
-            enabled = enabled,
-            isError = false,
-            interactionSource = interactionSource,
-            colors = TextFieldDefaults.colors(),
-        )
+                HtmlElementView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(inputMinHeight),
+                    factory = {
+                        val input = document.createElement("input") as HTMLInputElement
+                        input.id = inputId
+                        input.name = inputName
+                        input.type = inputType
+                        input.autocomplete = autocomplete
+                        input.setAttribute("form", FORM_ID)
+                        input.setAttribute("aria-label", label)
+                        input.required = true
+                        input
+                    },
+                    update = { input ->
+                        input.disabled = !enabled
+                        applyMinimalInputStyle(
+                            input = input,
+                            textStyle = textStyle,
+                            caretColor = colors.onSurface,
+                        )
 
-        HtmlElementView(
-            modifier = Modifier.fillMaxSize(),
-            factory = {
-                val container = document.createElement("div") as org.w3c.dom.HTMLElement
-                container.style.apply {
-                    position = "relative"
-                    width = "100%"
-                    height = "100%"
-                    margin = "0"
-                    padding = "0"
-                    border = "none"
-                }
+                        if (input.value != value) {
+                            input.value = value
+                        }
 
-                val labelElement = document.createElement("label") as HTMLLabelElement
-                labelElement.htmlFor = inputId
-                labelElement.textContent = label
-                applyVisuallyHiddenStyle(labelElement)
-
-                val input = document.createElement("input") as HTMLInputElement
-                input.id = inputId
-                input.name = inputName
-                input.type = inputType
-                input.autocomplete = autocomplete
-                input.setAttribute("form", FORM_ID)
-                input.required = true
-
-                container.append(labelElement, input)
-                container
-            },
-            update = { container ->
-                val input = container.querySelector("#$inputId") as HTMLInputElement
-
-                input.disabled = !enabled
-                applyMinimalInputStyle(
-                    input = input,
-                    textStyle = textStyle,
-                    caretColor = colors.onSurface,
+                        input.oninput = { event ->
+                            val newValue = readInputValue(event)
+                            if (newValue != value) {
+                                onValueChange(newValue)
+                            }
+                        }
+                        input.onchange = { event ->
+                            val newValue = readInputValue(event)
+                            if (newValue != value) {
+                                onValueChange(newValue)
+                            }
+                        }
+                    },
                 )
-
-                if (input.value != value) {
-                    input.value = value
-                }
-
-                input.oninput = { event ->
-                    val newValue = readInputValue(event)
-                    if (newValue != value) {
-                        onValueChange(newValue)
-                    }
-                }
-                input.onchange = { event ->
-                    val newValue = readInputValue(event)
-                    if (newValue != value) {
-                        onValueChange(newValue)
-                    }
-                }
-            },
-        )
-    }
-}
-
-private fun applyVisuallyHiddenStyle(labelElement: HTMLLabelElement) {
-    labelElement.style.apply {
-        position = "absolute"
-        width = "1px"
-        height = "1px"
-        padding = "0"
-        margin = "-1px"
-        setProperty("overflow", "hidden")
-        clip = "rect(0, 0, 0, 0)"
-        border = "0"
-    }
+            }
+        },
+        label = {
+            Text(label)
+        },
+        placeholder = null,
+        leadingIcon = null,
+        trailingIcon = null,
+        prefix = null,
+        suffix = null,
+        supportingText = null,
+        shape = MaterialTextFieldDefaults.shape,
+        singleLine = true,
+        enabled = enabled,
+        isError = false,
+        interactionSource = interactionSource,
+        colors = TextFieldDefaults.colors(),
+    )
 }
 
 private fun applyMinimalInputStyle(
@@ -245,9 +211,6 @@ private fun applyMinimalInputStyle(
 ) {
     input.style.apply {
         boxSizing = "border-box"
-        position = "absolute"
-        top = "0"
-        left = "0"
         width = "100%"
         height = "100%"
         margin = "0"
@@ -256,6 +219,8 @@ private fun applyMinimalInputStyle(
         outline = "none"
         backgroundColor = "transparent"
         color = "transparent"
+        setProperty("appearance", "none")
+        setProperty("-webkit-appearance", "none")
         setProperty("caret-color", caretColor.toCssColor())
         fontSize = "${textStyle.fontSize.value}px"
         fontFamily = textStyle.fontFamily?.toString() ?: "inherit"

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -1,23 +1,36 @@
 package net.matsudamper.money.frontend.common.ui.layout
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.HtmlElementView
 import kotlinx.browser.document
+import androidx.compose.material3.TextFieldDefaults as MaterialTextFieldDefaults
 import org.w3c.dom.HTMLFormElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLLabelElement
 import org.w3c.dom.events.Event
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
 public actual fun LoginCredentialsFields(
     username: String,
@@ -31,141 +44,62 @@ public actual fun LoginCredentialsFields(
     modifier: Modifier,
     enabled: Boolean,
 ) {
-    val colors = MaterialTheme.colorScheme
-    val labelStyle = MaterialTheme.typography.bodySmall
+    Column(modifier = modifier) {
+        HiddenLoginForm(
+            onSubmit = onSubmit,
+            enabled = enabled,
+        )
+        HtmlCredentialField(
+            label = usernameLabel,
+            value = username,
+            onValueChange = onUsernameChange,
+            inputId = USERNAME_INPUT_ID,
+            inputName = "username",
+            inputType = "text",
+            autocomplete = "username",
+            textStyle = textStyle,
+            enabled = enabled,
+            isPassword = false,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        HtmlCredentialField(
+            label = passwordLabel,
+            value = password,
+            onValueChange = onPasswordChange,
+            inputId = PASSWORD_INPUT_ID,
+            inputName = "password",
+            inputType = "password",
+            autocomplete = "current-password",
+            textStyle = textStyle,
+            enabled = enabled,
+            isPassword = true,
+        )
+    }
+}
 
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun HiddenLoginForm(
+    onSubmit: () -> Unit,
+    enabled: Boolean,
+) {
     HtmlElementView(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
-            .height(FIELD_HEIGHT),
+            .height(0.dp),
         factory = {
             val form = document.createElement("form") as HTMLFormElement
             form.id = FORM_ID
             form.setAttribute("autocomplete", "on")
             form.style.apply {
-                width = "100%"
-                height = "100%"
+                display = "none"
                 margin = "0"
                 padding = "0"
                 border = "none"
             }
-
-            val usernameLabelElement = document.createElement("label") as HTMLLabelElement
-            usernameLabelElement.htmlFor = USERNAME_INPUT_ID
-
-            val usernameInput = document.createElement("input") as HTMLInputElement
-            usernameInput.id = USERNAME_INPUT_ID
-            usernameInput.name = "username"
-            usernameInput.type = "text"
-            usernameInput.autocomplete = "username"
-            usernameInput.required = true
-            usernameInput.style.display = "block"
-
-            val passwordLabelElement = document.createElement("label") as HTMLLabelElement
-            passwordLabelElement.htmlFor = PASSWORD_INPUT_ID
-
-            val passwordInput = document.createElement("input") as HTMLInputElement
-            passwordInput.id = PASSWORD_INPUT_ID
-            passwordInput.name = "password"
-            passwordInput.type = "password"
-            passwordInput.autocomplete = "current-password"
-            passwordInput.required = true
-            passwordInput.style.display = "block"
-
-            form.append(
-                usernameLabelElement,
-                usernameInput,
-                passwordLabelElement,
-                passwordInput,
-            )
             form
         },
         update = { form ->
-            val usernameLabelElement = form.querySelector("label[for='$USERNAME_INPUT_ID']") as HTMLLabelElement
-            val usernameInput = form.querySelector("#$USERNAME_INPUT_ID") as HTMLInputElement
-            val passwordLabelElement = form.querySelector("label[for='$PASSWORD_INPUT_ID']") as HTMLLabelElement
-            val passwordInput = form.querySelector("#$PASSWORD_INPUT_ID") as HTMLInputElement
-
-            usernameLabelElement.textContent = usernameLabel
-            usernameLabelElement.style.apply {
-                display = "block"
-                marginBottom = "4px"
-                color = colors.onSurfaceVariant.toCssColor()
-                fontSize = "${labelStyle.fontSize.value}px"
-                fontFamily = labelStyle.fontFamily?.toString() ?: "inherit"
-            }
-
-            passwordLabelElement.textContent = passwordLabel
-            passwordLabelElement.style.apply {
-                display = "block"
-                marginTop = "8px"
-                marginBottom = "4px"
-                color = colors.onSurfaceVariant.toCssColor()
-                fontSize = "${labelStyle.fontSize.value}px"
-                fontFamily = labelStyle.fontFamily?.toString() ?: "inherit"
-            }
-
-            usernameInput.disabled = !enabled
-            usernameInput.style.apply {
-                boxSizing = "border-box"
-                width = "100%"
-                minHeight = "56px"
-                padding = "16px 12px"
-                borderRadius = "4px"
-                border = "1px solid ${colors.outline.toCssColor()}"
-                backgroundColor = colors.surface.toCssColor()
-                color = colors.onSurface.toCssColor()
-                fontSize = "${textStyle.fontSize.value}px"
-                fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
-            }
-
-            passwordInput.disabled = !enabled
-            passwordInput.style.apply {
-                boxSizing = "border-box"
-                width = "100%"
-                minHeight = "56px"
-                padding = "16px 12px"
-                borderRadius = "4px"
-                border = "1px solid ${colors.outline.toCssColor()}"
-                backgroundColor = colors.surface.toCssColor()
-                color = colors.onSurface.toCssColor()
-                fontSize = "${textStyle.fontSize.value}px"
-                fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
-            }
-
-            if (usernameInput.value != username) {
-                usernameInput.value = username
-            }
-            if (passwordInput.value != password) {
-                passwordInput.value = password
-            }
-
-            usernameInput.oninput = { event ->
-                val value = readInputValue(event)
-                if (value != username) {
-                    onUsernameChange(value)
-                }
-            }
-            usernameInput.onchange = { event ->
-                val value = readInputValue(event)
-                if (value != username) {
-                    onUsernameChange(value)
-                }
-            }
-
-            passwordInput.oninput = { event ->
-                val value = readInputValue(event)
-                if (value != password) {
-                    onPasswordChange(value)
-                }
-            }
-            passwordInput.onchange = { event ->
-                val value = readInputValue(event)
-                if (value != password) {
-                    onPasswordChange(value)
-                }
-            }
-
             form.onsubmit = { event ->
                 event.preventDefault()
                 if (enabled) {
@@ -174,6 +108,160 @@ public actual fun LoginCredentialsFields(
             }
         },
     )
+}
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun HtmlCredentialField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    inputId: String,
+    inputName: String,
+    inputType: String,
+    autocomplete: String,
+    textStyle: TextStyle,
+    enabled: Boolean,
+    isPassword: Boolean,
+) {
+    val colors = MaterialTheme.colorScheme
+    val interactionSource = remember { MutableInteractionSource() }
+    val visualTransformation = if (isPassword) {
+        PasswordVisualTransformation()
+    } else {
+        VisualTransformation.None
+    }
+    val displayText = visualTransformation.filter(AnnotatedString(value)).text
+
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        MaterialTextFieldDefaults.DecorationBox(
+            value = value,
+            visualTransformation = visualTransformation,
+            innerTextField = {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = displayText,
+                    style = textStyle,
+                    maxLines = 1,
+                )
+            },
+            label = {
+                Text(label)
+            },
+            placeholder = null,
+            leadingIcon = null,
+            trailingIcon = null,
+            prefix = null,
+            suffix = null,
+            supportingText = null,
+            shape = MaterialTextFieldDefaults.shape,
+            singleLine = true,
+            enabled = enabled,
+            isError = false,
+            interactionSource = interactionSource,
+            colors = TextFieldDefaults.colors(),
+        )
+
+        HtmlElementView(
+            modifier = Modifier.fillMaxSize(),
+            factory = {
+                val container = document.createElement("div") as org.w3c.dom.HTMLElement
+                container.style.apply {
+                    position = "relative"
+                    width = "100%"
+                    height = "100%"
+                    margin = "0"
+                    padding = "0"
+                    border = "none"
+                }
+
+                val labelElement = document.createElement("label") as HTMLLabelElement
+                labelElement.htmlFor = inputId
+                labelElement.textContent = label
+                applyVisuallyHiddenStyle(labelElement)
+
+                val input = document.createElement("input") as HTMLInputElement
+                input.id = inputId
+                input.name = inputName
+                input.type = inputType
+                input.autocomplete = autocomplete
+                input.setAttribute("form", FORM_ID)
+                input.required = true
+
+                container.append(labelElement, input)
+                container
+            },
+            update = { container ->
+                val input = container.querySelector("#$inputId") as HTMLInputElement
+
+                input.disabled = !enabled
+                applyMinimalInputStyle(
+                    input = input,
+                    textStyle = textStyle,
+                    caretColor = colors.onSurface,
+                )
+
+                if (input.value != value) {
+                    input.value = value
+                }
+
+                input.oninput = { event ->
+                    val newValue = readInputValue(event)
+                    if (newValue != value) {
+                        onValueChange(newValue)
+                    }
+                }
+                input.onchange = { event ->
+                    val newValue = readInputValue(event)
+                    if (newValue != value) {
+                        onValueChange(newValue)
+                    }
+                }
+            },
+        )
+    }
+}
+
+private fun applyVisuallyHiddenStyle(labelElement: HTMLLabelElement) {
+    labelElement.style.apply {
+        position = "absolute"
+        width = "1px"
+        height = "1px"
+        padding = "0"
+        margin = "-1px"
+        setProperty("overflow", "hidden")
+        clip = "rect(0, 0, 0, 0)"
+        border = "0"
+    }
+}
+
+private fun applyMinimalInputStyle(
+    input: HTMLInputElement,
+    textStyle: TextStyle,
+    caretColor: Color,
+) {
+    input.style.apply {
+        boxSizing = "border-box"
+        position = "absolute"
+        top = "0"
+        left = "0"
+        width = "100%"
+        height = "100%"
+        margin = "0"
+        padding = "0"
+        border = "none"
+        outline = "none"
+        backgroundColor = "transparent"
+        color = "transparent"
+        setProperty("caret-color", caretColor.toCssColor())
+        fontSize = "${textStyle.fontSize.value}px"
+        fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
+        lineHeight = textStyle.lineHeight.toString()
+        setProperty("-webkit-text-fill-color", "transparent")
+    }
 }
 
 private fun readInputValue(event: Event): String {
@@ -192,4 +280,3 @@ private fun Color.toCssColor(): String {
 private const val FORM_ID = "login-credentials-form"
 private const val USERNAME_INPUT_ID = "login-username"
 private const val PASSWORD_INPUT_ID = "login-password"
-private val FIELD_HEIGHT = 156.dp

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -1,0 +1,195 @@
+package net.matsudamper.money.frontend.common.ui.layout
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.HtmlElementView
+import kotlinx.browser.document
+import org.w3c.dom.HTMLFormElement
+import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.HTMLLabelElement
+import org.w3c.dom.events.Event
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+public actual fun LoginCredentialsFields(
+    username: String,
+    password: String,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    usernameLabel: String,
+    passwordLabel: String,
+    textStyle: TextStyle,
+    modifier: Modifier,
+    enabled: Boolean,
+) {
+    val colors = MaterialTheme.colorScheme
+    val labelStyle = MaterialTheme.typography.bodySmall
+
+    HtmlElementView(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(FIELD_HEIGHT),
+        factory = {
+            val form = document.createElement("form") as HTMLFormElement
+            form.id = FORM_ID
+            form.setAttribute("autocomplete", "on")
+            form.style.apply {
+                width = "100%"
+                height = "100%"
+                margin = "0"
+                padding = "0"
+                border = "none"
+            }
+
+            val usernameLabelElement = document.createElement("label") as HTMLLabelElement
+            usernameLabelElement.htmlFor = USERNAME_INPUT_ID
+
+            val usernameInput = document.createElement("input") as HTMLInputElement
+            usernameInput.id = USERNAME_INPUT_ID
+            usernameInput.name = "username"
+            usernameInput.type = "text"
+            usernameInput.autocomplete = "username"
+            usernameInput.required = true
+            usernameInput.style.display = "block"
+
+            val passwordLabelElement = document.createElement("label") as HTMLLabelElement
+            passwordLabelElement.htmlFor = PASSWORD_INPUT_ID
+
+            val passwordInput = document.createElement("input") as HTMLInputElement
+            passwordInput.id = PASSWORD_INPUT_ID
+            passwordInput.name = "password"
+            passwordInput.type = "password"
+            passwordInput.autocomplete = "current-password"
+            passwordInput.required = true
+            passwordInput.style.display = "block"
+
+            form.append(
+                usernameLabelElement,
+                usernameInput,
+                passwordLabelElement,
+                passwordInput,
+            )
+            form
+        },
+        update = { form ->
+            val usernameLabelElement = form.querySelector("label[for='$USERNAME_INPUT_ID']") as HTMLLabelElement
+            val usernameInput = form.querySelector("#$USERNAME_INPUT_ID") as HTMLInputElement
+            val passwordLabelElement = form.querySelector("label[for='$PASSWORD_INPUT_ID']") as HTMLLabelElement
+            val passwordInput = form.querySelector("#$PASSWORD_INPUT_ID") as HTMLInputElement
+
+            usernameLabelElement.textContent = usernameLabel
+            usernameLabelElement.style.apply {
+                display = "block"
+                marginBottom = "4px"
+                color = colors.onSurfaceVariant.toCssColor()
+                fontSize = "${labelStyle.fontSize.value}px"
+                fontFamily = labelStyle.fontFamily?.toString() ?: "inherit"
+            }
+
+            passwordLabelElement.textContent = passwordLabel
+            passwordLabelElement.style.apply {
+                display = "block"
+                marginTop = "8px"
+                marginBottom = "4px"
+                color = colors.onSurfaceVariant.toCssColor()
+                fontSize = "${labelStyle.fontSize.value}px"
+                fontFamily = labelStyle.fontFamily?.toString() ?: "inherit"
+            }
+
+            usernameInput.disabled = !enabled
+            usernameInput.style.apply {
+                boxSizing = "border-box"
+                width = "100%"
+                minHeight = "56px"
+                padding = "16px 12px"
+                borderRadius = "4px"
+                border = "1px solid ${colors.outline.toCssColor()}"
+                backgroundColor = colors.surface.toCssColor()
+                color = colors.onSurface.toCssColor()
+                fontSize = "${textStyle.fontSize.value}px"
+                fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
+            }
+
+            passwordInput.disabled = !enabled
+            passwordInput.style.apply {
+                boxSizing = "border-box"
+                width = "100%"
+                minHeight = "56px"
+                padding = "16px 12px"
+                borderRadius = "4px"
+                border = "1px solid ${colors.outline.toCssColor()}"
+                backgroundColor = colors.surface.toCssColor()
+                color = colors.onSurface.toCssColor()
+                fontSize = "${textStyle.fontSize.value}px"
+                fontFamily = textStyle.fontFamily?.toString() ?: "inherit"
+            }
+
+            if (usernameInput.value != username) {
+                usernameInput.value = username
+            }
+            if (passwordInput.value != password) {
+                passwordInput.value = password
+            }
+
+            usernameInput.oninput = { event ->
+                val value = readInputValue(event)
+                if (value != username) {
+                    onUsernameChange(value)
+                }
+            }
+            usernameInput.onchange = { event ->
+                val value = readInputValue(event)
+                if (value != username) {
+                    onUsernameChange(value)
+                }
+            }
+
+            passwordInput.oninput = { event ->
+                val value = readInputValue(event)
+                if (value != password) {
+                    onPasswordChange(value)
+                }
+            }
+            passwordInput.onchange = { event ->
+                val value = readInputValue(event)
+                if (value != password) {
+                    onPasswordChange(value)
+                }
+            }
+
+            form.onsubmit = { event ->
+                event.preventDefault()
+                if (enabled) {
+                    onSubmit()
+                }
+            }
+        },
+    )
+}
+
+private fun readInputValue(event: Event): String {
+    val target = event.target
+    return (target as? HTMLInputElement)?.value ?: ""
+}
+
+private fun Color.toCssColor(): String {
+    val argb = toArgb()
+    val r = (argb shr 16) and 0xFF
+    val g = (argb shr 8) and 0xFF
+    val b = argb and 0xFF
+    return "rgb($r, $g, $b)"
+}
+
+private const val FORM_ID = "login-credentials-form"
+private const val USERNAME_INPUT_ID = "login-username"
+private const val PASSWORD_INPUT_ID = "login-password"
+private val FIELD_HEIGHT = 156.dp

--- a/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
+++ b/frontend/common/ui/src/jsMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/LoginCredentialsFields.js.kt
@@ -2,6 +2,7 @@ package net.matsudamper.money.frontend.common.ui.layout
 
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -13,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -34,6 +36,9 @@ import org.w3c.dom.events.Event
 
 private val CredentialFieldMinHeight = 56.dp
 private val CredentialFieldHorizontalPadding = 16.dp
+private val CredentialFieldExpandedTopPadding = 24.dp
+private val CredentialFieldExpandedBottomPadding = 8.dp
+private val CredentialFieldCollapsedVerticalPadding = 16.dp
 
 private class FocusInteractionHolder {
     var focus: FocusInteraction.Focus? = null
@@ -136,12 +141,30 @@ private fun HtmlCredentialField(
         VisualTransformation.None
     }
     val textFieldColors = TextFieldDefaults.colors()
+    val focused by interactionSource.collectIsFocusedAsState()
+    val labelExpanded = focused || value.isNotEmpty()
 
     SubcomposeLayout(
         modifier = Modifier
             .fillMaxWidth()
             .defaultMinSize(minHeight = CredentialFieldMinHeight),
     ) { constraints ->
+        val expandedTopPaddingPx = CredentialFieldExpandedTopPadding.roundToPx()
+        val expandedBottomPaddingPx = CredentialFieldExpandedBottomPadding.roundToPx()
+        val topPaddingPx = if (labelExpanded) {
+            expandedTopPaddingPx
+        } else {
+            CredentialFieldCollapsedVerticalPadding.roundToPx()
+        }
+        val bottomPaddingPx = if (labelExpanded) {
+            expandedBottomPaddingPx
+        } else {
+            CredentialFieldCollapsedVerticalPadding.roundToPx()
+        }
+        val horizontalPaddingPx = CredentialFieldHorizontalPadding.roundToPx()
+        val fontSizePx = textStyle.fontSize.toPx()
+        val letterSpacingPx = textStyle.letterSpacing.toPx()
+
         val decorationPlaceable = subcompose("decoration") {
             MaterialTextFieldDefaults.DecorationBox(
                 value = value,
@@ -171,9 +194,6 @@ private fun HtmlCredentialField(
         val overlayHeight = decorationPlaceable.height
         val overlayWidthDp = overlayWidth.toDp()
         val overlayHeightDp = overlayHeight.toDp()
-        val horizontalPaddingPx = CredentialFieldHorizontalPadding.roundToPx()
-        val fontSizePx = textStyle.fontSize.toPx()
-        val letterSpacingPx = textStyle.letterSpacing.toPx()
 
         val overlayPlaceable = subcompose("overlay") {
             HtmlElementView(
@@ -199,6 +219,8 @@ private fun HtmlCredentialField(
                         textColor = colors.onSurface,
                         caretColor = colors.onSurface,
                         horizontalPaddingPx = horizontalPaddingPx,
+                        topPaddingPx = topPaddingPx,
+                        bottomPaddingPx = bottomPaddingPx,
                         fontSizePx = fontSizePx,
                         letterSpacingPx = letterSpacingPx,
                     )
@@ -206,6 +228,19 @@ private fun HtmlCredentialField(
                         input = input,
                         interactionSource = interactionSource,
                         focusInteractionHolder = focusInteractionHolder,
+                        onFocusStyle = {
+                            applyInputStyle(
+                                input = input,
+                                textStyle = textStyle,
+                                textColor = colors.onSurface,
+                                caretColor = colors.onSurface,
+                                horizontalPaddingPx = horizontalPaddingPx,
+                                topPaddingPx = expandedTopPaddingPx,
+                                bottomPaddingPx = expandedBottomPaddingPx,
+                                fontSizePx = fontSizePx,
+                                letterSpacingPx = letterSpacingPx,
+                            )
+                        },
                     )
 
                     if (input.value != value) {
@@ -246,6 +281,7 @@ private fun bindFocusHandlers(
     input: HTMLInputElement,
     interactionSource: MutableInteractionSource,
     focusInteractionHolder: FocusInteractionHolder,
+    onFocusStyle: () -> Unit,
 ) {
     input.onfocus = {
         if (focusInteractionHolder.focus == null) {
@@ -253,6 +289,7 @@ private fun bindFocusHandlers(
             focusInteractionHolder.focus = focus
             interactionSource.tryEmit(focus)
         }
+        onFocusStyle()
     }
     input.onblur = {
         val focus = focusInteractionHolder.focus
@@ -269,22 +306,18 @@ private fun applyInputStyle(
     textColor: Color,
     caretColor: Color,
     horizontalPaddingPx: Int,
+    topPaddingPx: Int,
+    bottomPaddingPx: Int,
     fontSizePx: Float,
     letterSpacingPx: Float,
 ) {
-    val clientHeight = input.clientHeight
-    val verticalPaddingPx = if (clientHeight > 0) {
-        ((clientHeight - fontSizePx) / 2f).coerceAtLeast(0f)
-    } else {
-        0f
-    }
     input.style.apply {
         boxSizing = "border-box"
         width = "100%"
         height = "100%"
         margin = "0"
-        paddingTop = "${verticalPaddingPx}px"
-        paddingBottom = "${verticalPaddingPx}px"
+        paddingTop = "${topPaddingPx}px"
+        paddingBottom = "${bottomPaddingPx}px"
         paddingLeft = "${horizontalPaddingPx}px"
         paddingRight = "${horizontalPaddingPx}px"
         border = "none"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# なぜやるか

canvas 上の Compose `TextField` ではブラウザのパスワードマネージャーがフィールドを認識できない。HTML input を埋め込んで AutoFill を有効にする。

# 実装した事

- `LoginCredentialsFields` を expect/actual で追加（JS: HTML 埋め込み、Android: 既存 `TextField`）
- 装飾（枠線・ラベル）は Compose の `DecorationBox` が担当
- HTML `input` は `innerTextField` にだけ置く（パスワードマネージャー用の最小入力）
- フィールド全体のクリックで HTML input にフォーカス（クリック範囲を確保）
- フォーカスは `interactionSource` に転送し、hint はフォーカス直後に上へ移動
- 入力テキスト位置は `DecorationBox` の標準 padding に従い、hint だけが動く
- CSS `font-size` は `sp.value` を使う（`toPx()` だと density 倍で文字が巨大化する）

## テスト

- `./gradlew :frontend:app:jsBrowserDevelopmentWebpack`
- `./gradlew ktlintFormat`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6612753b-c534-4051-abdb-739396a783a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6612753b-c534-4051-abdb-739396a783a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ログイン画面に、ユーザー名とパスワードをまとめて入力できるフォームを追加しました。
  * 入力ラベル、入力可否、オートコンプリート、パスワード保護に対応しました。
  * Enterキーなどによるログイン送信に対応しました。

* **改善**
  * AndroidとWebで一貫したログイン入力体験を提供します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->