### PR TITLE
追加・詳細画面で画像の長押し入れ替えを追加

### DIFF
--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/image/MoneyUsageImageThumbnail.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/image/MoneyUsageImageThumbnail.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
@@ -17,7 +18,10 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
+import net.matsudamper.money.frontend.common.ui.AppRoot
 import net.matsudamper.money.frontend.common.ui.layout.AlertDialog
 
 @Composable
@@ -92,6 +96,35 @@ public fun MoneyUsageImageThumbnail(
                 onClickNegative = { showDeleteDialog = false },
                 onDismissRequest = { showDeleteDialog = false },
             )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun MoneyUsageImageThumbnailMenuPreview() {
+    AppRoot(isDarkTheme = false) {
+        Box(modifier = Modifier.size(120.dp)) {
+            SubcomposeAsyncImage(
+                model = "https://picsum.photos/seed/kakebo-preview/240/240",
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+                loading = { ImageLoadingPlaceholder() },
+            )
+            DropdownMenu(
+                expanded = true,
+                onDismissRequest = {},
+            ) {
+                DropdownMenuItem(
+                    text = { Text("入れ替え") },
+                    onClick = {},
+                )
+                DropdownMenuItem(
+                    text = { Text("削除") },
+                    onClick = {},
+                )
+            }
         }
     }
 }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/image/MoneyUsageImageThumbnail.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/layout/image/MoneyUsageImageThumbnail.kt
@@ -1,0 +1,97 @@
+package net.matsudamper.money.frontend.common.ui.layout.image
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.SubcomposeAsyncImage
+import net.matsudamper.money.frontend.common.ui.layout.AlertDialog
+
+@Composable
+public fun MoneyUsageImageThumbnail(
+    url: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    onClickReplace: () -> Unit,
+    onClickDelete: () -> Unit,
+) {
+    var showPopupMenu by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        SubcomposeAsyncImage(
+            model = url,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = { onClick() },
+                        onLongPress = { showPopupMenu = true },
+                    )
+                }
+                .pointerInput(Unit) {
+                    awaitEachGesture {
+                        val pressEvent = awaitPointerEvent()
+                        if (pressEvent.type != PointerEventType.Press) return@awaitEachGesture
+                        if (pressEvent.buttons.isSecondaryPressed.not()) return@awaitEachGesture
+
+                        while (true) {
+                            val releaseEvent = awaitPointerEvent()
+                            if (releaseEvent.type != PointerEventType.Release) continue
+                            showPopupMenu = true
+                            break
+                        }
+                    }
+                },
+            loading = { ImageLoadingPlaceholder() },
+        )
+        DropdownMenu(
+            expanded = showPopupMenu,
+            onDismissRequest = { showPopupMenu = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("入れ替え") },
+                onClick = {
+                    showPopupMenu = false
+                    onClickReplace()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("削除") },
+                onClick = {
+                    showPopupMenu = false
+                    showDeleteDialog = true
+                },
+            )
+        }
+        if (showDeleteDialog) {
+            AlertDialog(
+                title = { Text("画像を削除しますか？") },
+                description = { Text("この操作は取り消せません。") },
+                positiveButton = { Text("削除") },
+                negativeButton = { Text("キャンセル") },
+                onClickPositive = {
+                    showDeleteDialog = false
+                    onClickDelete()
+                },
+                onClickNegative = { showDeleteDialog = false },
+                onDismissRequest = { showDeleteDialog = false },
+            )
+        }
+    }
+}

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/addmoneyusage/AddMoneyUsageScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/addmoneyusage/AddMoneyUsageScreen.kt
@@ -1,6 +1,5 @@
 package net.matsudamper.money.frontend.common.ui.screen.addmoneyusage
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,14 +40,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
-import coil3.compose.SubcomposeAsyncImage
 import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.ui.AppRoot
 import net.matsudamper.money.frontend.common.ui.base.CategorySelectDialog
@@ -65,15 +62,26 @@ import net.matsudamper.money.frontend.common.ui.layout.NumberInputValue
 import net.matsudamper.money.frontend.common.ui.layout.SnackbarEventState
 import net.matsudamper.money.frontend.common.ui.layout.TimePickerDialog
 import net.matsudamper.money.frontend.common.ui.layout.html.text.fullscreen.FullScreenTextInput
-import net.matsudamper.money.frontend.common.ui.layout.image.ImageLoadingPlaceholder
 import net.matsudamper.money.frontend.common.ui.layout.image.ImageUploadButton
+import net.matsudamper.money.frontend.common.ui.layout.image.MoneyUsageImageThumbnail
 import net.matsudamper.money.frontend.common.ui.layout.image.ZoomableImageDialog
 import net.matsudamper.money.frontend.common.ui.lib.asWindowInsets
 import org.jetbrains.compose.resources.painterResource
 
 public sealed interface ImageItem {
     public data object Uploading : ImageItem
-    public data class Uploaded(val url: String) : ImageItem
+
+    public data class Uploaded(
+        val url: String,
+        val event: UploadedEvent,
+    ) : ImageItem
+
+    @Immutable
+    public interface UploadedEvent {
+        public fun onClickReplace()
+
+        public fun onClickDelete()
+    }
 }
 
 public data class AddMoneyUsageScreenUiState(
@@ -370,14 +378,12 @@ public fun AddMoneyUsageScreen(
                                                 }
                                             }
                                             is ImageItem.Uploaded -> {
-                                                SubcomposeAsyncImage(
-                                                    model = image.url,
-                                                    contentDescription = null,
-                                                    contentScale = ContentScale.Crop,
-                                                    modifier = Modifier
-                                                        .size(120.dp)
-                                                        .clickable { selectedImageUrl = image.url },
-                                                    loading = { ImageLoadingPlaceholder() },
+                                                MoneyUsageImageThumbnail(
+                                                    url = image.url,
+                                                    modifier = Modifier.size(120.dp),
+                                                    onClick = { selectedImageUrl = image.url },
+                                                    onClickReplace = { image.event.onClickReplace() },
+                                                    onClickDelete = { image.event.onClickDelete() },
                                                 )
                                             }
                                         }

--- a/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/moneyusage/MoneyUsageScreen.kt
+++ b/frontend/common/ui/src/commonMain/kotlin/net/matsudamper/money/frontend/common/ui/screen/moneyusage/MoneyUsageScreen.kt
@@ -2,7 +2,6 @@ package net.matsudamper.money.frontend.common.ui.screen.moneyusage
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -26,8 +25,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -46,8 +43,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
@@ -57,7 +52,6 @@ import androidx.compose.ui.window.PopupProperties
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import coil3.compose.AsyncImage
-import coil3.compose.SubcomposeAsyncImage
 import net.matsudamper.money.frontend.common.base.ImmutableList
 import net.matsudamper.money.frontend.common.ui.LocalIsLargeScreen
 import net.matsudamper.money.frontend.common.ui.base.CategorySelectDialog
@@ -79,8 +73,8 @@ import net.matsudamper.money.frontend.common.ui.layout.TimePickerDialog
 import net.matsudamper.money.frontend.common.ui.layout.UrlClickableText
 import net.matsudamper.money.frontend.common.ui.layout.UrlMenuDialog
 import net.matsudamper.money.frontend.common.ui.layout.html.text.fullscreen.FullScreenTextInput
-import net.matsudamper.money.frontend.common.ui.layout.image.ImageLoadingPlaceholder
 import net.matsudamper.money.frontend.common.ui.layout.image.ImageUploadButton
+import net.matsudamper.money.frontend.common.ui.layout.image.MoneyUsageImageThumbnail
 import net.matsudamper.money.frontend.common.ui.layout.image.ZoomableImageDialog
 import org.jetbrains.compose.resources.painterResource
 
@@ -169,6 +163,8 @@ public data class MoneyUsageScreenUiState(
 
     @Immutable
     public interface ImageItemEvent {
+        public fun onClickReplace()
+
         public fun onClickDelete()
     }
 
@@ -675,66 +671,13 @@ private fun ImageItemContent(
     imageItem: MoneyUsageScreenUiState.ImageItem,
     onClick: () -> Unit,
 ) {
-    var showDeleteDialog by remember { mutableStateOf(false) }
-    var showPopupMenu by remember { mutableStateOf(false) }
-
-    Box(modifier = Modifier.fillMaxSize()) {
-        SubcomposeAsyncImage(
-            model = imageItem.url,
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable { onClick() }
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { onClick() },
-                        onLongPress = { showPopupMenu = true },
-                    )
-                }
-                .pointerInput(Unit) {
-                    awaitEachGesture {
-                        val pressEvent = awaitPointerEvent()
-                        if (pressEvent.type != PointerEventType.Press) return@awaitEachGesture
-                        if (pressEvent.buttons.isSecondaryPressed.not()) return@awaitEachGesture
-
-                        while (true) {
-                            val releaseEvent = awaitPointerEvent()
-                            if (releaseEvent.type != PointerEventType.Release) continue
-                            showPopupMenu = true
-                            break
-                        }
-                    }
-                },
-            loading = { ImageLoadingPlaceholder() },
-        )
-        DropdownMenu(
-            expanded = showPopupMenu,
-            onDismissRequest = { showPopupMenu = false },
-        ) {
-            DropdownMenuItem(
-                text = { Text("削除") },
-                onClick = {
-                    showPopupMenu = false
-                    showDeleteDialog = true
-                },
-            )
-        }
-        if (showDeleteDialog) {
-            AlertDialog(
-                title = { Text("画像を削除しますか？") },
-                description = { Text("この操作は取り消せません。") },
-                positiveButton = { Text("削除") },
-                negativeButton = { Text("キャンセル") },
-                onClickPositive = {
-                    showDeleteDialog = false
-                    imageItem.event.onClickDelete()
-                },
-                onClickNegative = { showDeleteDialog = false },
-                onDismissRequest = { showDeleteDialog = false },
-            )
-        }
-    }
+    MoneyUsageImageThumbnail(
+        url = imageItem.url,
+        modifier = Modifier.fillMaxSize(),
+        onClick = onClick,
+        onClickReplace = { imageItem.event.onClickReplace() },
+        onClickDelete = { imageItem.event.onClickDelete() },
+    )
 }
 
 @Composable

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/addmoneyusage/AddMoneyUsageViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/addmoneyusage/AddMoneyUsageViewModel.kt
@@ -254,25 +254,7 @@ public class AddMoneyUsageViewModel(
 
                 try {
                     images.forEach { image ->
-                        val imageBytes = image.bytes ?: return@forEach
-                        val uploadResult = graphqlApi.uploadImage(
-                            bytes = imageBytes,
-                            contentType = image.contentType,
-                        )
-
-                        if (uploadResult != null) {
-                            viewModelStateFlow.update { viewModelState ->
-                                viewModelState.copy(
-                                    usageImages = (
-                                        viewModelState.usageImages + ViewModelState.UploadedImage(
-                                            imageId = uploadResult.imageId,
-                                            url = uploadResult.url,
-                                        )
-                                        ).distinctBy { it.imageId.value },
-                                    hasInputChanges = true,
-                                )
-                            }
-                        }
+                        uploadImage(image)
                     }
                 } finally {
                     viewModelStateFlow.update {
@@ -303,6 +285,72 @@ public class AddMoneyUsageViewModel(
                 }
             }
         }
+    }
+
+    private fun createUploadedImageEvent(imageId: ImageId): ImageItem.UploadedEvent {
+        return object : ImageItem.UploadedEvent {
+            override fun onClickReplace() {
+                viewModelScope.launch {
+                    val images = eventSender.send { it.selectImages() }
+                    val newImage = images.firstOrNull() ?: return@launch
+
+                    viewModelStateFlow.update {
+                        it.copy(uploadingImageCount = it.uploadingImageCount + 1)
+                    }
+
+                    try {
+                        val uploadResult = uploadImage(newImage)
+                        if (uploadResult != null) {
+                            viewModelStateFlow.update { viewModelState ->
+                                viewModelState.copy(
+                                    usageImages = viewModelState.usageImages
+                                        .filter { it.imageId != imageId }
+                                        .distinctBy { it.imageId.value },
+                                    hasInputChanges = true,
+                                )
+                            }
+                        }
+                    } finally {
+                        viewModelStateFlow.update {
+                            it.copy(uploadingImageCount = (it.uploadingImageCount - 1).coerceAtLeast(0))
+                        }
+                    }
+                }
+            }
+
+            override fun onClickDelete() {
+                viewModelStateFlow.update { viewModelState ->
+                    viewModelState.copy(
+                        usageImages = viewModelState.usageImages.filter { it.imageId != imageId },
+                        hasInputChanges = true,
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun uploadImage(image: SelectedImage): ViewModelState.UploadedImage? {
+        val imageBytes = image.bytes ?: return null
+        val uploadResult = graphqlApi.uploadImage(
+            bytes = imageBytes,
+            contentType = image.contentType,
+        )
+
+        if (uploadResult == null) return null
+
+        val uploadedImage = ViewModelState.UploadedImage(
+            imageId = uploadResult.imageId,
+            url = uploadResult.url,
+        )
+        viewModelStateFlow.update { viewModelState ->
+            viewModelState.copy(
+                usageImages = (
+                    viewModelState.usageImages + uploadedImage
+                    ).distinctBy { it.imageId.value },
+                hasInputChanges = true,
+            )
+        }
+        return uploadedImage
     }
 
     private fun addMoneyUsage() {
@@ -530,7 +578,14 @@ public class AddMoneyUsageViewModel(
                             "$category / $subCategory"
                         },
                         images = buildList {
-                            addAll(viewModelState.usageImages.map { ImageItem.Uploaded(url = it.url) })
+                            addAll(
+                                viewModelState.usageImages.map { uploadedImage ->
+                                    ImageItem.Uploaded(
+                                        url = uploadedImage.url,
+                                        event = createUploadedImageEvent(uploadedImage.imageId),
+                                    )
+                                },
+                            )
                             repeat(viewModelState.uploadingImageCount) { add(ImageItem.Uploading) }
                         }.toImmutableList(),
                         addButtonEnabled = viewModelState.uploadingImageCount == 0,

--- a/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/moneyusage/MoneyUsageScreenViewModel.kt
+++ b/frontend/common/viewmodel/src/commonMain/kotlin/net/matsudamper/money/frontend/common/viewmodel/moneyusage/MoneyUsageScreenViewModel.kt
@@ -429,6 +429,31 @@ public class MoneyUsageScreenViewModel(
 
     private fun createImageItemEvent(imageId: ImageId): MoneyUsageScreenUiState.ImageItemEvent {
         return object : MoneyUsageScreenUiState.ImageItemEvent {
+            override fun onClickReplace() {
+                viewModelScope.launch {
+                    val images = eventSender.send { it.selectImages() }
+                    val newImage = images.firstOrNull() ?: return@launch
+
+                    val isSuccess = api.deleteImage(
+                        usageId = moneyUsageId,
+                        imageId = imageId,
+                    )
+                    if (!isSuccess) {
+                        eventSender.send {
+                            it.showToast("画像の入れ替えに失敗しました")
+                        }
+                        return@launch
+                    }
+
+                    eventSender.send { it.requestNotificationPermission() }
+                    imageUploadQueue.enqueue(
+                        moneyUsageId = moneyUsageId,
+                        selectedImage = newImage,
+                    )
+                    fetch(policy = FetchPolicy.NetworkOnly)
+                }
+            }
+
             override fun onClickDelete() {
                 viewModelScope.launch {
                     val isSuccess = api.deleteImage(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

追加画面（`AddMoneyUsageScreen`）と詳細画面（`MoneyUsageScreen`）で、画像サムネイルを長押し（デスクトップでは右クリック）すると「入れ替え」「削除」メニューを表示し、画像を入れ替えできるようにしました。

## 変更内容

- `MoneyUsageImageThumbnail` を共通化し、長押しでメニュー表示・削除確認ダイアログを実装
- **追加画面**: 新しい画像をアップロードして既存画像をリストから除去（入れ替え）、リストから除去（削除）
- **詳細画面**: 既存画像を API で削除後に新しい画像をアップロードキューへ追加（入れ替え）。削除は従来どおり

## UI 確認（Paparazzi）

[長押しメニュー（入れ替え・削除）](https://cursor.com/agents/bc-ac80a413-3ca8-4e83-8ac3-71f0950487c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimage-long-press-menu-preview.png)

## テスト

- `./gradlew :backend:assemble :frontend:app:jsBrowserDevelopmentWebpack :frontend:android:app:assembleDebug --quiet` 成功
- `./gradlew ktlintFormat` 実行済み
- Paparazzi でメニュー表示プレビューを記録
- Web UI の実機確認はバックエンド未起動のためログイン画面まで（メニュー操作の E2E はバックエンド接続が必要）

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac80a413-3ca8-4e83-8ac3-71f0950487c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac80a413-3ca8-4e83-8ac3-71f0950487c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 利用明細の画像サムネイルを追加しました。
  - 画像のタップで拡大表示できます。
  - 長押しまたは右クリックから、画像の入れ替え・削除を選択できます。
  - 画像削除前に確認ダイアログを表示します。
  - 入れ替えた画像をアップロードし、最新情報を自動取得します。

- **改善**
  - 画像操作を追加・利用明細画面で統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->